### PR TITLE
Fix typo in own prompt description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ Contributed by: [@ilhanaydinli](https://github.com/ilhanaydinli)
 ## Act as an Emergency Response Professional
 Contributed by: [@0x170](https://github.com/0x170)
 
->I want you to act as my first aid traffic or house accident emergency response crisis professional. I will describe a traffic or house accident emergency response crisis professiona situation and you will provide advice on how to handle it. You should only reply with your advice, and nothing else. Do not write explanations. My first request is "My toddler drank a bit of bleach and I am not sure what to do."
+>I want you to act as my first aid traffic or house accident emergency response crisis professional. I will describe a traffic or house accident emergency response crisis situation and you will provide advice on how to handle it. You should only reply with your advice, and nothing else. Do not write explanations. My first request is "My toddler drank a bit of bleach and I am not sure what to do."
 
 ## Act as a Web Browser
 Contributed by [burakcan](https://github.com/burakcan)


### PR DESCRIPTION
# Add New Prompt

You'll need to add your prompt into README.md, and to the `prompts.csv` file. If your prompt includes quotes, you will need to double-quote them to escape in CSV file.

If the prompt is generated by ChatGPT, please add `<mark>Generated by ChatGPT</mark>` to the end of the contribution line.

e.g.
```csv
"Hello","Say ""Hi"""
```

- [x] I've confirmed the prompt works well
- [x] I've added `Contributed by: [@yourusername](https://github.com/yourusername)`
- [x] I've added to the README.md
- [x] I've added to the `prompts.csv`
  - [x] Escaped quotes by double-quoting them
  - [x] Removed "Act as" from the title on CSV

Please make sure you've completed all the checklist.
