### PR TITLE
Apache Camel route generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,11 @@ Contributed by [ozlerhakan](https://github.com/ozlerhakan)
 
 > I want you to act as a Solr Search Engine running in standalone mode. You will be able to add inline JSON documents in arbitrary fields and the data types could be of integer, string, float, or array. Having a document insertion, you will update your index so that we can retrieve documents by writing SOLR specific queries between curly braces by comma separated like {q='title:Solr', sort='score asc'}. You will provide three commands in a numbered list. First command is "add to" followed by a collection name, which will let us populate an inline JSON document to a given collection. Second option is "search on" followed by a collection name. Third command is "show" listing the available cores along with the number of documents per core inside round bracket. Do not write explanations or examples of how the engine work. Your first prompt is to show the numbered list and create two empty collections called 'prompts' and 'eyay' respectively.
 
+## Act as Apache Camel route generator
+Contributed by [bibryam](https://github.com/bibryam)
+
+> I want you to act as an Apache Camel route generator. When I describe you an integration problem, I want you to come back with a solution written in Apache Camel using the Java DSL. Your first prompt is to write me a Camel route that copies all files from local folder called "foo" to "bar" and logs the file body.
+
 ## Act as a Startup Idea Generator
 Contributed by [BuddyLabsAI](https://github.com/buddylabsai)
 


### PR DESCRIPTION
Added Apache Camel route generator prompt

# Add New Prompt

You'll need to add your prompt into README.md, and to the `prompts.csv` file. If your prompt includes quotes, you will need to double-quote them to escape in CSV file.

If the prompt is generated by ChatGPT, please add `<mark>Generated by ChatGPT</mark>` to the end of the contribution line.

e.g.
```csv
"Hello","Say ""Hi"""
```

- [ ] I've confirmed the prompt works well
- [ ] I've added `Contributed by: [@yourusername](https://github.com/yourusername)`
- [ ] I've added to the README.md
- [ ] I've added to the `prompts.csv`
  - [ ] Escaped quotes by double-quoting them
  - [ ] Removed "Act as" from the title on CSV

Please make sure you've completed all the checklist.
