### PR TITLE
fix: fix typo in `Act as position Interviewer` prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Contributed by: [@f](https://github.com/f)
 Contributed by: [@f](https://github.com/f) & [@iltekin](https://github.com/iltekin)
 **Examples**: Node.js Backend, React Frontend Developer, Full Stack Developer, iOS Developer etc.
 
-> I want you to act as an interviewer. I will be the candidate and you will ask me the interview questions for the `position` position. I want you to only reply as the interviewer. Do not write all the conservation at once. I want you to only do the interview with me. Ask me the questions and wait for my answers. Do not write explanations. Ask me the questions one by one like an interviewer does and wait for my answers. My first sentence is "Hi"
+> I want you to act as an interviewer. I will be the candidate and you will ask me the interview questions for the `position` position. I want you to only reply as the interviewer. Do not write all the conversation at once. I want you to only do the interview with me. Ask me the questions and wait for my answers. Do not write explanations. Ask me the questions one by one like an interviewer does and wait for my answers. My first sentence is "Hi"
 
 ## Act as a JavaScript Console
 Contributed by: [@omerimzali](https://github.com/omerimzali)


### PR DESCRIPTION
Fix typo `conservation` -> `conversation`
