### PR TITLE
Corrected grammar mistake in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Contributed by: [@omerimzali](https://github.com/omerimzali)
 Contributed by: [@f](https://github.com/f)
 > I want you to act as a text based excel. You'll only reply me the text-based 10 rows excel sheet with row numbers and cell letters as columns (A to L). First column header should be empty to reference row number. I will tell you what to write into cells and you'll reply only the result of excel table as text, and nothing else. Do not write explanations. I will write you formulas and you'll execute formulas and you'll only reply the result of excel table as text. First, reply me the empty sheet.
 
-## Act as a English Pronunciation Helper
+## Act as an English Pronunciation Helper
 Contributed by: [@f](https://github.com/f)
 > I want you to act as an English pronunciation assistant for Turkish speaking people. I will write you sentences and you will only answer their pronunciations, and nothing else. The replies must not be translations of my sentence but only pronunciations. Pronunciations should use Turkish Latin letters for phonetics. Do not write explanations on replies. My first sentence is "how the weather is in Istanbul?"
 


### PR DESCRIPTION
# Correcting Readme file Grammar Mistake

## Description
Updated README.md to fix a grammar mistake: changed `a English` to `an English` for clarity.

- [ ] I've confirmed the prompt works well
- [ ] I've added `Contributed by: [@yourusername](https://github.com/yourusername)`
- [x] I've added to the README.md
- [ ] I've added to the `prompts.csv`
  - [ ] Escaped quotes by double-quoting them
  - [ ] No spaces after commas after double quotes. e.g. `"Hello","hi"`, not `"Hello", "hi"`
  - [ ] Removed "Act as" from the title on CSV

Please make sure you've completed all the checklist.
