### PR TITLE
Add sponsor wall to showcase supporters

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,9 @@
       <h1><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1>
       {% endif %}
 
+      <!-- Navigation link to sponsor-wall.html added -->
+      <p><a href="{{ '/sponsor-wall.html' | relative_url }}">Sponsor Wall</a></p>
+
       {{ content }}
 
       {% if site.github.private != true and site.github.license %}

--- a/sponsor-wall.html
+++ b/sponsor-wall.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sponsor Wall</title>
+    <style>
+        .grid-container {
+            display: grid;
+            grid-template-columns: auto auto auto;
+            padding: 10px;
+        }
+        .grid-item {
+            padding: 20px;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Sponsor Wall</h1>
+    </header>
+    <p>This page is dedicated to all our amazing sponsors who have supported us. Thank you for your contributions!</p>
+    <div class="grid-container">
+        <!-- Sponsor logos will be added here -->
+        <div class="grid-item">Sponsor 1 Logo</div>
+        <div class="grid-item">Sponsor 2 Logo</div>
+        <div class="grid-item">Sponsor 3 Logo</div>
+        <!-- More sponsors can be added in similar divs -->
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a new feature to the `f/awesome-chatgpt-prompts` repository by adding a sponsor wall, enhancing the project's community engagement and support recognition.

- **Adds a new HTML page (`sponsor-wall.html`)** to display a wall of sponsor logos, including a header titled "Sponsor Wall" and a brief description thanking the sponsors for their support. The page layout is designed with a grid format to showcase sponsor logos.
- **Updates the `_layouts/default.html` file** by inserting a navigation link to the newly created `sponsor-wall.html`, allowing easy access to the sponsor wall from any page within the site.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/f/awesome-chatgpt-prompts?shareId=9ec47225-bd46-4dcc-bc7a-8d8048a1e54f).