### PR TITLE
Add dark mode and publish to GitHub Pages using GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ The _unofficial_ ChatGPT desktop application provides a convenient way to access
 
 ---
 
+## Dark Mode Implementation
+
+We have implemented a dark mode for this repository to enhance your reading experience. The dark mode is implemented using CSS variables and a toggle button. You can switch between light and dark modes by clicking the toggle button.
+
+## GitHub Pages Deployment using GitHub Actions
+
+We have set up a GitHub Actions workflow to automatically publish this repository to GitHub Pages. This workflow ensures that the latest changes are always available on the GitHub Pages site. You can find the workflow configuration in the `.github/workflows/publish.yml` file.
+
 # Prompts
 
 ## ChatGPT SEO prompts

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,10 @@
 name: Awesome ChatGPT Prompts
 title: null
+
+# Dark mode configuration
+dark_mode: true
+
+# GitHub Pages configuration
+github_pages:
+  url: "https://<your-github-username>.github.io/<your-repo-name>"
+  branch: "gh-pages"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,10 +7,45 @@
 
 {% seo %}
     <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <style>
+      :root {
+        --bg-color-light: #ffffff;
+        --bg-color-dark: #1a1a1a;
+        --text-color-light: #000000;
+        --text-color-dark: #ffffff;
+      }
+
+      body {
+        background-color: var(--bg-color-light);
+        color: var(--text-color-light);
+      }
+
+      body.dark-mode {
+        background-color: var(--bg-color-dark);
+        color: var(--text-color-dark);
+      }
+
+      .dark-mode-toggle {
+        position: fixed;
+        top: 1rem;
+        right: 1rem;
+        background-color: var(--bg-color-light);
+        color: var(--text-color-light);
+        border: none;
+        padding: 0.5rem;
+        cursor: pointer;
+      }
+
+      body.dark-mode .dark-mode-toggle {
+        background-color: var(--bg-color-dark);
+        color: var(--text-color-dark);
+      }
+    </style>
     {% include head-custom.html %}
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6945602608405209" crossorigin="anonymous"></script>
   </head>
   <body>
+    <button class="dark-mode-toggle" onclick="toggleDarkMode()">🌞</button>
     <div class="container-lg px-3 my-5 markdown-body">
       {% if site.title and site.title != page.title %}
       <h1><a href="{{ "/" | absolute_url }}">{{ site.title }}</a></h1>
@@ -46,6 +81,22 @@
           }
         }, false);
         x.previousElementSibling.previousElementSibling.prepend(button);
+      });
+
+      function toggleDarkMode() {
+        const body = document.body;
+        body.classList.toggle('dark-mode');
+        const isDarkMode = body.classList.contains('dark-mode');
+        localStorage.setItem('dark-mode', isDarkMode);
+        document.querySelector('.dark-mode-toggle').textContent = isDarkMode ? '🌙' : '🌞';
+      }
+
+      document.addEventListener('DOMContentLoaded', () => {
+        const isDarkMode = localStorage.getItem('dark-mode') === 'true';
+        if (isDarkMode) {
+          document.body.classList.add('dark-mode');
+          document.querySelector('.dark-mode-toggle').textContent = '🌙';
+        }
       });
     </script>
     <style>video { max-width: 100% !important; }</style>


### PR DESCRIPTION
Add dark mode and GitHub Pages deployment using GitHub Actions

* **Dark Mode Implementation**
  - Add CSS variables for dark mode in `_layouts/default.html`
  - Add a toggle button for dark mode in `_layouts/default.html`
  - Add JavaScript to handle dark mode toggle in `_layouts/default.html`
  - Update `README.md` to include a section about dark mode implementation
* **GitHub Pages Deployment**
  - Add a GitHub Actions workflow for publishing to GitHub Pages in `.github/workflows/publish.yml`
  - Include steps for checking out the repository, setting up Jekyll, and deploying to GitHub Pages in the workflow
  - Update `README.md` to include a section about GitHub Pages deployment using GitHub Actions
  - Update `_config.yml` to include configuration for GitHub Pages


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/f/awesome-chatgpt-prompts?shareId=72a820eb-5bf3-47a4-b7fa-ae750cb32c35).