### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@
 ---
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
+<!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/f/awesome-chatgpt-prompts?lang=de) | 
+[Español](https://www.readme-i18n.com/f/awesome-chatgpt-prompts?lang=es) | 
+[français](https://www.readme-i18n.com/f/awesome-chatgpt-prompts?lang=fr) | 
+[日本語](https://www.readme-i18n.com/f/awesome-chatgpt-prompts?lang=ja) | 
+[한국어](https://www.readme-i18n.com/f/awesome-chatgpt-prompts?lang=ko) | 
+[Português](https://www.readme-i18n.com/f/awesome-chatgpt-prompts?lang=pt) | 
+[Русский](https://www.readme-i18n.com/f/awesome-chatgpt-prompts?lang=ru) | 
+[中文](https://www.readme-i18n.com/f/awesome-chatgpt-prompts?lang=zh)
+
 Welcome to the "Awesome ChatGPT Prompts" repository! While this collection was originally created for [ChatGPT](https://chat.openai.com/chat), these prompts work great with other AI models like [Claude](https://claude.ai/new), [Gemini](https://gemini.google.com), [Hugging Face Chat](https://hf.co/chat), [Llama](https://meta.ai), [Mistral](https://chat.mistral.ai), and more.
 
 [ChatGPT](https://chat.openai.com/chat) is a web interface created by [OpenAI](https://openai.com) that provides access to their GPT (Generative Pre-trained Transformer) language models. The underlying models, like GPT-4o and GPT-o1, are large language models trained on vast amounts of text data that can understand and generate human-like text. Like other AI chat interfaces, you can provide prompts and have natural conversations with the AI, which will generate contextual responses based on the conversation history and your inputs.


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated can be previewed in my forked repository: https://github.com/dowithless/awesome-chatgpt-prompts/tree/patch-1

# Add New Prompt

You'll need to add your prompt into README.md, and to the `prompts.csv` file. If
your prompt includes quotes, you will need to double-quote them to escape in CSV
file.

If the prompt is generated by AI, please add `<mark>Generated by AI</mark>` to
the end of the contribution line.

- [ ] I've confirmed the prompt works well
- [ ] I've added
      `Contributed by: [@yourusername](https://github.com/yourusername)`
- [ ] I've added to the README.md
- [ ] I've added to the `prompts.csv`
  - [ ] Escaped quotes by double-quoting them
  - [ ] No spaces after commas after double quotes. e.g. `"Hello","hi"`, not
        `"Hello", "hi"`
  - [ ] Removed "Act as" from the title on CSV

Please make sure you've completed all the checklist.
