### PR TITLE
feat(api): Add public endpoints for categories and tags

### DIFF
--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,24 @@
+import { db } from "@/lib/db";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const categories = await db.category.findMany({
+      orderBy: [{ order: "asc" }, { name: "asc" }],
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        parentId: true,
+      },
+    });
+
+    return NextResponse.json({ categories });
+  } catch (error) {
+    console.error("Failed to fetch categories:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch categories" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,0 +1,18 @@
+import { db } from "@/lib/db";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const tags = await db.tag.findMany({
+      orderBy: { name: "asc" },
+    });
+
+    return NextResponse.json({ tags });
+  } catch (error) {
+    console.error("Failed to fetch tags:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch tags" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds two public API endpoints for categories and tags metadata:
- `GET /api/categories` - Returns all categories (id, name, slug, parentId)
- `GET /api/tags` - Returns all tags (alphabetically sorted)
## Why
I'm working on a significant update to the [prompts.chat extension](https://github.com/fatihsolhan/prompts-chat-extension), and these endpoints would be super helpful for:
- **Consistent filtering** - Match the same category/tag filters as the main site
- **Staying in sync** - Follow [prompts.chat](prompts.chat) patterns instead of client-side workarounds
- **Better UX** - Enable proper dropdowns with all available options

Having these as first-class API endpoints ensures the extension stays aligned with how prompts.chat organizes prompts.
## Changes
- `app/api/categories/route.ts` - Categories ordered by `order`, then `name`
- `app/api/tags/route.ts` - Tags ordered alphabetically

Both endpoints follow the same patterns as the existing `/api/prompts` endpoint.

---
Happy to adjust anything if needed! 🙏