### PR TITLE
feat: Add JSON format warning dialog for text prompts

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "تعلم كيفية كتابة أوامر فعالة ←",
     "structuredFormatDetected": "تم اكتشاف تنسيق {format}",
     "structuredFormatWarningDescription": "يبدو أن محتوى الأمر الخاص بك يشبه بيانات منظمة. فكر في التبديل إلى الوضع المنظم للحصول على تمييز بنائي وتحقق أفضل.",
-    "switchToStructured": "التبديل إلى {format}"
+    "switchToStructured": "التبديل إلى {format}",
+    "jsonFormatWarningTitle": "تم اكتشاف تنسيق JSON",
+    "jsonFormatWarningDescription": "يبدو أن محتوى الأمر الخاص بك بتنسيق JSON، لكنك اخترت نوع النص. هل تريد التبديل إلى التنسيق المنظم للحصول على تمييز بنائي وتحقق أفضل؟",
+    "continueAnyway": "المتابعة على أي حال",
+    "switchToStructuredFormat": "التبديل إلى التنسيق المنظم"
   },
   "changeRequests": {
     "title": "طلبات التغيير",

--- a/messages/de.json
+++ b/messages/de.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "Lernen Sie, effektive Prompts zu schreiben →",
     "structuredFormatDetected": "{format}-Format erkannt",
     "structuredFormatWarningDescription": "Ihr Prompt-Inhalt sieht nach strukturierten Daten aus. Erwägen Sie den Wechsel in den strukturierten Modus für bessere Syntaxhervorhebung und Validierung.",
-    "switchToStructured": "Zu {format} wechseln"
+    "switchToStructured": "Zu {format} wechseln",
+    "jsonFormatWarningTitle": "JSON-Format Erkannt",
+    "jsonFormatWarningDescription": "Ihr Prompt-Inhalt scheint im JSON-Format zu sein, aber Sie haben den Typ Text ausgewählt. Möchten Sie zum Strukturierten Format wechseln, um eine bessere Syntaxhervorhebung und Validierung zu erhalten?",
+    "continueAnyway": "Trotzdem Fortfahren",
+    "switchToStructuredFormat": "Zum Strukturierten Format Wechseln"
   },
   "changeRequests": {
     "title": "Änderungsanfragen",

--- a/messages/el.json
+++ b/messages/el.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "Μάθετε πώς να γράφετε αποτελεσματικά prompts →",
     "structuredFormatDetected": "Εντοπίστηκε μορφή {format}",
     "structuredFormatWarningDescription": "Το περιεχόμενο του prompt σας μοιάζει με δομημένα δεδομένα. Σκεφτείτε να αλλάξετε σε δομημένη λειτουργία για καλύτερη επισήμανση σύνταξης και επικύρωση.",
-    "switchToStructured": "Αλλαγή σε {format}"
+    "switchToStructured": "Αλλαγή σε {format}",
+    "jsonFormatWarningTitle": "Εντοπίστηκε Μορφή JSON",
+    "jsonFormatWarningDescription": "Το περιεχόμενο του prompt σας φαίνεται να είναι σε μορφή JSON, αλλά έχετε επιλέξει τον τύπο Κείμενο. Θα θέλατε να αλλάξετε σε δομημένη μορφή για καλύτερη επισήμανση σύνταξης και επικύρωση;",
+    "continueAnyway": "Συνέχεια Ούτως ή Άλλως",
+    "switchToStructuredFormat": "Αλλαγή σε Δομημένη Μορφή"
   },
   "changeRequests": {
     "title": "Αιτήσεις αλλαγής",

--- a/messages/en.json
+++ b/messages/en.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "Learn how to write effective prompts →",
     "structuredFormatDetected": "{format} format detected",
     "structuredFormatWarningDescription": "Your prompt content looks like structured data. Consider switching to structured mode for better syntax highlighting and validation.",
-    "switchToStructured": "Switch to {format}"
+    "switchToStructured": "Switch to {format}",
+    "jsonFormatWarningTitle": "JSON Format Detected",
+    "jsonFormatWarningDescription": "Your prompt content appears to be in JSON format, but you've selected Text type. Would you like to switch to Structured format for better syntax highlighting and validation?",
+    "continueAnyway": "Continue Anyway",
+    "switchToStructuredFormat": "Switch to Structured Format"
   },
   "changeRequests": {
     "title": "Change Requests",

--- a/messages/es.json
+++ b/messages/es.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "Aprende a escribir prompts efectivos →",
     "structuredFormatDetected": "Formato {format} detectado",
     "structuredFormatWarningDescription": "El contenido de tu prompt parece ser datos estructurados. Considera cambiar al modo estructurado para mejor resaltado de sintaxis y validación.",
-    "switchToStructured": "Cambiar a {format}"
+    "switchToStructured": "Cambiar a {format}",
+    "jsonFormatWarningTitle": "Formato JSON Detectado",
+    "jsonFormatWarningDescription": "El contenido de tu prompt parece estar en formato JSON, pero has seleccionado el tipo Texto. ¿Te gustaría cambiar al formato Estructurado para mejor resaltado de sintaxis y validación?",
+    "continueAnyway": "Continuar de Todos Modos",
+    "switchToStructuredFormat": "Cambiar a Formato Estructurado"
   },
   "changeRequests": {
     "title": "Solicitudes de Cambio",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "Apprenez à écrire des prompts efficaces →",
     "structuredFormatDetected": "Format {format} détecté",
     "structuredFormatWarningDescription": "Le contenu de votre prompt ressemble à des données structurées. Envisagez de passer en mode structuré pour une meilleure coloration syntaxique et validation.",
-    "switchToStructured": "Passer à {format}"
+    "switchToStructured": "Passer à {format}",
+    "jsonFormatWarningTitle": "Format JSON Détecté",
+    "jsonFormatWarningDescription": "Le contenu de votre prompt semble être au format JSON, mais vous avez sélectionné le type Texte. Souhaitez-vous passer au format Structuré pour une meilleure coloration syntaxique et validation ?",
+    "continueAnyway": "Continuer Quand Même",
+    "switchToStructuredFormat": "Passer au Format Structuré"
   },
   "changeRequests": {
     "title": "Demandes de Modification",

--- a/messages/he.json
+++ b/messages/he.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "למדו איך לכתוב פרומפטים יעילים ←",
     "structuredFormatDetected": "זוהה פורמט {format}",
     "structuredFormatWarningDescription": "תוכן הפרומפט שלך נראה כמו נתונים מובנים. שקול לעבור למצב מובנה להדגשת תחביר ואימות טובים יותר.",
-    "switchToStructured": "לעבור ל-{format}"
+    "switchToStructured": "לעבור ל-{format}",
+    "jsonFormatWarningTitle": "זוהה פורמט JSON",
+    "jsonFormatWarningDescription": "תוכן הפרומפט שלך נראה בפורמט JSON, אבל בחרת בסוג טקסט. האם תרצה לעבור לפורמט מובנה להדגשת תחביר ואימות טובים יותר?",
+    "continueAnyway": "להמשיך בכל מקרה",
+    "switchToStructuredFormat": "לעבור לפורמט מובנה"
   },
   "changeRequests": {
     "title": "בקשות שינוי",

--- a/messages/it.json
+++ b/messages/it.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "Impara a scrivere prompt efficaci →",
     "structuredFormatDetected": "Formato {format} rilevato",
     "structuredFormatWarningDescription": "Il contenuto del tuo prompt sembra essere dati strutturati. Considera di passare alla modalità strutturata per una migliore evidenziazione della sintassi e validazione.",
-    "switchToStructured": "Passa a {format}"
+    "switchToStructured": "Passa a {format}",
+    "jsonFormatWarningTitle": "Formato JSON Rilevato",
+    "jsonFormatWarningDescription": "Il contenuto del tuo prompt sembra essere in formato JSON, ma hai selezionato il tipo Testo. Vorresti passare al formato Strutturato per una migliore evidenziazione della sintassi e validazione?",
+    "continueAnyway": "Continua Comunque",
+    "switchToStructuredFormat": "Passa al Formato Strutturato"
   },
   "changeRequests": {
     "title": "Richieste di Modifica",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "効果的なプロンプトの書き方を学ぶ →",
     "structuredFormatDetected": "{format}形式が検出されました",
     "structuredFormatWarningDescription": "プロンプトの内容が構造化データのようです。より良い構文ハイライトと検証のために構造化モードへの切り替えを検討してください。",
-    "switchToStructured": "{format}に切り替え"
+    "switchToStructured": "{format}に切り替え",
+    "jsonFormatWarningTitle": "JSON形式が検出されました",
+    "jsonFormatWarningDescription": "プロンプトの内容がJSON形式のようですが、テキストタイプを選択しています。より良い構文ハイライトと検証のために構造化形式に切り替えますか？",
+    "continueAnyway": "そのまま続行",
+    "switchToStructuredFormat": "構造化形式に切り替え"
   },
   "changeRequests": {
     "title": "変更リクエスト",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "효과적인 프롬프트 작성법 배우기 →",
     "structuredFormatDetected": "{format} 형식 감지됨",
     "structuredFormatWarningDescription": "프롬프트 내용이 구조화된 데이터처럼 보입니다. 더 나은 구문 강조 표시 및 유효성 검사를 위해 구조화 모드로 전환하는 것을 고려해 보세요.",
-    "switchToStructured": "{format}으로 전환"
+    "switchToStructured": "{format}으로 전환",
+    "jsonFormatWarningTitle": "JSON 형식 감지됨",
+    "jsonFormatWarningDescription": "프롬프트 내용이 JSON 형식인 것 같지만 텍스트 유형을 선택했습니다. 더 나은 구문 강조 표시 및 유효성 검사를 위해 구조화 형식으로 전환하시겠습니까?",
+    "continueAnyway": "그래도 계속",
+    "switchToStructuredFormat": "구조화 형식으로 전환"
   },
   "changeRequests": {
     "title": "변경 요청",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "Aprenda a escrever prompts eficazes →",
     "structuredFormatDetected": "Formato {format} detectado",
     "structuredFormatWarningDescription": "O conteúdo do seu prompt parece ser dados estruturados. Considere mudar para o modo estruturado para melhor destaque de sintaxe e validação.",
-    "switchToStructured": "Mudar para {format}"
+    "switchToStructured": "Mudar para {format}",
+    "jsonFormatWarningTitle": "Formato JSON Detectado",
+    "jsonFormatWarningDescription": "O conteúdo do seu prompt parece estar em formato JSON, mas você selecionou o tipo Texto. Gostaria de mudar para o formato Estruturado para melhor destaque de sintaxe e validação?",
+    "continueAnyway": "Continuar Mesmo Assim",
+    "switchToStructuredFormat": "Mudar para Formato Estruturado"
   },
   "changeRequests": {
     "title": "Solicitações de Alteração",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "Узнайте, как писать эффективные промпты →",
     "structuredFormatDetected": "Обнаружен формат {format}",
     "structuredFormatWarningDescription": "Содержимое вашего промпта похоже на структурированные данные. Рассмотрите переключение в структурированный режим для лучшей подсветки синтаксиса и валидации.",
-    "switchToStructured": "Переключить на {format}"
+    "switchToStructured": "Переключить на {format}",
+    "jsonFormatWarningTitle": "Обнаружен формат JSON",
+    "jsonFormatWarningDescription": "Содержимое вашего промпта, похоже, в формате JSON, но вы выбрали тип Текст. Хотите переключиться на структурированный формат для лучшей подсветки синтаксиса и валидации?",
+    "continueAnyway": "Все равно продолжить",
+    "switchToStructuredFormat": "Переключить на структурированный формат"
   },
   "changeRequests": {
     "title": "Запросы на изменение",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "Etkili promptlar nasıl yazılır öğrenin →",
     "structuredFormatDetected": "{format} formatı algılandı",
     "structuredFormatWarningDescription": "Prompt içeriğiniz yapılandırılmış veriye benziyor. Daha iyi sözdizimi vurgulama ve doğrulama için yapılandırılmış moda geçmeyi düşünün.",
-    "switchToStructured": "{format}'a geç"
+    "switchToStructured": "{format}'a geç",
+    "jsonFormatWarningTitle": "JSON Formatı Algılandı",
+    "jsonFormatWarningDescription": "Prompt içeriğiniz JSON formatında görünüyor, ancak Metin türünü seçtiniz. Daha iyi sözdizimi vurgulama ve doğrulama için Yapılandırılmış formata geçmek ister misiniz?",
+    "continueAnyway": "Yine de Devam Et",
+    "switchToStructuredFormat": "Yapılandırılmış Formata Geç"
   },
   "changeRequests": {
     "title": "Değişiklik İstekleri",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -359,7 +359,11 @@
     "learnHowToWritePrompts": "学习如何写出有效的提示词 →",
     "structuredFormatDetected": "检测到 {format} 格式",
     "structuredFormatWarningDescription": "您的提示词内容看起来像结构化数据。考虑切换到结构化模式以获得更好的语法高亮和验证。",
-    "switchToStructured": "切换到 {format}"
+    "switchToStructured": "切换到 {format}",
+    "jsonFormatWarningTitle": "检测到 JSON 格式",
+    "jsonFormatWarningDescription": "您的提示词内容似乎是 JSON 格式，但您选择了文本类型。您想切换到结构化格式以获得更好的语法高亮和验证吗？",
+    "continueAnyway": "仍然继续",
+    "switchToStructuredFormat": "切换到结构化格式"
   },
   "changeRequests": {
     "title": "变更请求",

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -22,3 +22,35 @@ export function isValidJson(content: string): boolean {
     return false;
   }
 }
+
+/**
+ * Detects if text content looks like JSON
+ * More lenient than isValidJson - catches JSON-like content even if not perfectly valid
+ */
+export function looksLikeJson(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+  
+  // Check if it starts and ends with JSON object/array delimiters
+  const startsWithJsonDelimiter = trimmed.startsWith("{") || trimmed.startsWith("[");
+  const endsWithJsonDelimiter = trimmed.endsWith("}") || trimmed.endsWith("]");
+  
+  if (startsWithJsonDelimiter && endsWithJsonDelimiter) {
+    // Additional check: try to parse it as JSON
+    try {
+      JSON.parse(trimmed);
+      return true;
+    } catch {
+      // Even if it doesn't parse perfectly, if it has JSON-like structure, warn the user
+      // Look for patterns like "key": value
+      const hasJsonKeyPattern = /"[^"]+"\s*:/g.test(trimmed);
+      return hasJsonKeyPattern;
+    }
+  }
+  
+  // Check for multiline JSON-like content that might have text before/after
+  const jsonObjectPattern = /^\s*\{[\s\S]*"[^"]+"\s*:[\s\S]*\}\s*$/;
+  const jsonArrayPattern = /^\s*\[[\s\S]*\{[\s\S]*"[^"]+"\s*:[\s\S]*\}[\s\S]*\]\s*$/;
+  
+  return jsonObjectPattern.test(trimmed) || jsonArrayPattern.test(trimmed);
+}


### PR DESCRIPTION
## Summary
Adds a confirmation dialog that warns users when they attempt to submit a prompt with JSON-formatted content while having TEXT type selected (instead of STRUCTURED format).

## Problem
Users may accidentally paste JSON content into a text prompt without realizing they should use the Structured format. This can lead to:
- Poor syntax highlighting
- Missing validation
- Confusion about the prompt format

## Solution
- Intercepts form submission to detect JSON-like content when TEXT type is selected
- Shows an AlertDialog with three options:
  - **Continue Anyway**: Proceeds with submission as-is
  - **Switch to Structured Format**: Automatically switches to JSON structured format
  - **Cancel**: Closes dialog without submitting

## Changes
- Added `looksLikeJson()` utility function to `src/lib/format.ts` for JSON detection
- Modified `prompt-form.tsx` to intercept submission and show warning dialog
- Added AlertDialog component with user-friendly messaging
- Added translations for all 14 supported locales (en, tr, es, fr, de, it, ja, ko, pt, zh, ar, ru, el, he)

## Testing
1. Create a new prompt
2. Paste JSON content (e.g., `{"key": "value"}`)
3. Keep TEXT type selected (don't switch to Structured)
4. Click "Create Prompt"
5. Verify the warning dialog appears
6. Test all three options:
   - Continue Anyway → Should submit successfully
   - Switch to Structured Format → Should update form to structured mode
   - Cancel → Should close dialog without submitting

## Related
Improves UX by preventing accidental submission of structured content as plain text.