### PR TITLE
docs: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,10 +19,10 @@ jobs:
       DATABASE_URL: "postgresql://test:test@localhost:5432/test"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -66,7 +66,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -11,13 +11,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Full history needed for commit deduplication
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
## Description

Updated outdated GitHub Action versions in the workflows.

## Type of Change

- [ ] Bug fix
- [ ] Documentation update
- [x] Other (please describe): Updating GitHub Action versions to ensure compatibility and security

---

## Changes

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/update-contributors.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/docker-publish.yml`
- Updated `actions/setup-python` from `v5` to `v6` in `.github/workflows/update-contributors.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/docker-publish.yml`
- Updated `docker/build-push-action` from `v5` to `v6` in `.github/workflows/docker-publish.yml`

---

## Additional Notes

<!-- Any additional context or screenshots -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest versions across CI/CD pipelines for improved platform compatibility and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->