### PR TITLE
Add Opik observability note in MCP integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Use prompts.chat as an MCP server in your AI tools.
 
 📖 [MCP Documentation](https://prompts.chat/docs/api)
 
+### Observability
+For tracing and evaluation of LLM and agent workflows, you can connect your MCP-based stack to [Opik](https://github.com/comet-ml/opik).
+
 ---
 
 ## 💖 Sponsors


### PR DESCRIPTION
## Summary
- Add a short observability note in the MCP integrations section referencing [Opik](https://github.com/comet-ml/opik).

## Why
- Teams using MCP workflows often need tracing/evaluation for prompt and agent behavior.

## Scope
- README-only docs tweak (non-prompt contribution).
