### PR TITLE
fix(docker): Add supervisorctl section

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,3 +1,13 @@
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [supervisord]
 nodaemon=true
 user=root


### PR DESCRIPTION
## Description

Fixes an issue where the Docker deployment crashes and keeps restarting during the `Starting Next.js...` phase. 

The error `Error: .ini file does not include supervisorctl section` occurs because [supervisord.conf](cci:7://file:///c:/Users/yashm/OneDrive/Desktop/Open%20Source/prompts.chat/docker/supervisord.conf:0:0-0:0) is missing the configuration blocks required for `supervisorctl` to communicate with `supervisord`. This PR adds the standard `[unix_http_server]`, `[supervisorctl]`, and `[rpcinterface:supervisor]` blocks to fix this issue.

## Type of Change

- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supervisor configuration to use UNIX socket-based communication for enhanced service control and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->