### PR TITLE
Fix(docker): remove premature nextjs start

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -134,10 +134,6 @@ cd "$APP_DIR"
 npx prisma migrate deploy
 echo "✓ Migrations complete"
 
-# Start Next.js
-echo "▶ Starting Next.js..."
-/usr/bin/supervisorctl -c /etc/supervisor/conf.d/supervisord.conf start nextjs
-
 # Seed on first run only
 SEED_MARKER="/data/.seeded"
 if [ ! -f "$SEED_MARKER" ]; then


### PR DESCRIPTION
## Description
Issue in the Docker setup causing error on boot:

`bootstrap.sh` called `supervisorctl start nextjs` twice — once immediately after migrations, and again after the supervisord readiness check — causing:
   > nextjs: ERROR (already started)

## Fix
- Removed the premature `supervisorctl start nextjs` call from `bootstrap.sh`, keeping only the one after the supervisord readiness check

## Type of Change

- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Additional Notes

<!-- Any additional context or screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the application startup sequence to ensure proper initialization order of critical components before the main application begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->