### PR TITLE
fix(docker): add unix socket config and improve supervisord readiness check

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -173,7 +173,7 @@ for i in $(seq 1 30); do
         echo "✗ Supervisord failed to start"
         echo "Debug info:"
         echo "  Socket exists: $([ -S /var/run/supervisor.sock ] && echo yes || echo no)"
-        echo "  Supervisord PID: $SUPERVISOR_PID (running: $(kill -0 $SUPERVISOR_PID 2>/dev/null && echo yes || echo no))"
+        echo "  Supervisord PID: $SUPERVISOR_PID (running: $(kill -0 "$SUPERVISOR_PID" 2>/dev/null && echo yes || echo no))"
         echo "Supervisorctl status output:"
         supervisorctl -s unix:///var/run/supervisor.sock status || true
         echo "Supervisord log:"

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -149,12 +149,30 @@ fi
 # Wait for supervisord socket to be ready
 echo "▶ Waiting for supervisord..."
 for i in $(seq 1 30); do
-    if supervisorctl -c /etc/supervisor/conf.d/supervisord.conf status >/dev/null 2>&1; then
-        echo "✓ Supervisord is ready"
-        break
+    # Check if supervisord process is running
+    if ! kill -0 $SUPERVISOR_PID 2>/dev/null; then
+        echo "✗ Supervisord process died"
+        cat /var/log/supervisor/supervisord.log 2>/dev/null || true
+        exit 1
+    fi
+    
+    # Check if socket exists and supervisorctl responds (status may be non-zero if a program is stopped)
+    if [ -S /var/run/supervisor.sock ]; then
+        STATUS_OUTPUT=$(supervisorctl -s unix:///var/run/supervisor.sock status 2>/dev/null || true)
+        if [ -n "$STATUS_OUTPUT" ]; then
+            echo "✓ Supervisord is ready"
+            break
+        fi
     fi
     if [ $i -eq 30 ]; then
         echo "✗ Supervisord failed to start"
+        echo "Debug info:"
+        echo "  Socket exists: $([ -S /var/run/supervisor.sock ] && echo yes || echo no)"
+        echo "  Supervisord PID: $SUPERVISOR_PID (running: $(kill -0 $SUPERVISOR_PID 2>/dev/null && echo yes || echo no))"
+        echo "Supervisorctl status output:"
+        supervisorctl -s unix:///var/run/supervisor.sock status || true
+        echo "Supervisord log:"
+        cat /var/log/supervisor/supervisord.log 2>/dev/null || echo "  No log file found"
         exit 1
     fi
     sleep 1

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -114,9 +114,19 @@ echo "▶ Starting services..."
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf &
 SUPERVISOR_PID=$!
 
+# Fail fast if supervisord dies during any startup phase
+check_supervisord_alive() {
+    if ! kill -0 "$SUPERVISOR_PID" 2>/dev/null; then
+        echo "✗ Supervisord process died"
+        cat /var/log/supervisor/supervisord.log 2>/dev/null || true
+        exit 1
+    fi
+}
+
 # Wait for PostgreSQL
 echo "▶ Waiting for PostgreSQL..."
 for i in $(seq 1 30); do
+    check_supervisord_alive
     if $PGBIN/pg_isready -h localhost -p 5432 >/dev/null 2>&1; then
         echo "✓ PostgreSQL is ready"
         break
@@ -149,12 +159,7 @@ fi
 # Wait for supervisord socket to be ready
 echo "▶ Waiting for supervisord..."
 for i in $(seq 1 30); do
-    # Check if supervisord process is running
-    if ! kill -0 $SUPERVISOR_PID 2>/dev/null; then
-        echo "✗ Supervisord process died"
-        cat /var/log/supervisor/supervisord.log 2>/dev/null || true
-        exit 1
-    fi
+    check_supervisord_alive
     
     # Check if socket exists and supervisorctl responds (status may be non-zero if a program is stopped)
     if [ -S /var/run/supervisor.sock ]; then
@@ -187,7 +192,7 @@ echo "╔═══════════════════════�
 echo "║                                                               ║"
 echo "║   ✅ prompts.chat is running!                                 ║"
 echo "║                                                               ║"
-echo "║   🌐 Open http://localhost:${PORT:-80} in your browser            ║"
+echo "║   🌐 Open http://localhost:${PORT:-80} in your browser        ║"
 echo "║                                                               ║"
 echo "╚═══════════════════════════════════════════════════════════════╝"
 echo ""

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,3 +1,13 @@
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [supervisord]
 nodaemon=true
 user=root


### PR DESCRIPTION
## Description

Fix Docker container startup failure caused by missing supervisord Unix socket configuration.

**Problem**: `supervisorctl` could not communicate with `supervisord` because the Unix socket was never declared in **[supervisord.conf]**. This caused the bootstrap readiness loop to always time out, even when supervisord was running correctly.

**Changes**:
- `[supervisord.conf]`: Added [unix_http_server], [supervisorctl], and [rpcinterface:supervisor] sections to configure the Unix socket at /var/run/supervisor.sock
- `[bootstrap.sh]`: Improved the supervisord readiness check to:
    - Detect early process termination and fail fast (instead of waiting 30s)
    - Gate supervisorctl calls on socket file existence
    - Use the Unix socket URL directly (unix:///var/run/supervisor.sock)
    - Print debug info on startup failure to help with troubleshooting

## Type of Change

- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## Additional Notes

Tested by verifying the supervisord socket handshake sequence in the bootstrap loop. Without the [unix_http_server] section, supervisord never creates the socket file, so supervisorctl status always fails silently and the container exits after the 30-iteration timeout.

<img width="1432" height="975" alt="image" src="https://github.com/user-attachments/assets/6fe0aa42-73ac-42ff-bb79-1f972098c9a9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker container startup reliability with enhanced service validation and multi-step health checks, including fast-fail detection of the supervisor process.
  * On startup timeout, emits richer diagnostic information to aid troubleshooting (socket, process and log details).
  * Added Unix-socket support for supervisor management interface.
  * Minor UI text alignment tweak in the final startup banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->