### PR TITLE
fix(#1025): prevent nextauth configuration crashes for unconfigured providers

### DIFF
--- a/src/lib/plugins/auth/apple.ts
+++ b/src/lib/plugins/auth/apple.ts
@@ -4,10 +4,14 @@ import type { AuthPlugin } from "../types";
 export const applePlugin: AuthPlugin = {
   id: "apple",
   name: "Apple",
-  getProvider: () =>
-    Apple({
-      clientId: process.env.AUTH_APPLE_ID!,
-      clientSecret: process.env.AUTH_APPLE_SECRET!,
+  getProvider: () => {
+    if (!process.env.AUTH_APPLE_ID || !process.env.AUTH_APPLE_SECRET) {
+      console.warn("Missing AUTH_APPLE_ID or AUTH_APPLE_SECRET. Apple auth provider disabled.");
+      return null;
+    }
+    return Apple({
+      clientId: process.env.AUTH_APPLE_ID,
+      clientSecret: process.env.AUTH_APPLE_SECRET,
       profile(profile) {
         return {
           id: profile.sub,
@@ -18,5 +22,6 @@ export const applePlugin: AuthPlugin = {
           image: null,
         };
       },
-    }),
+    });
+  },
 };

--- a/src/lib/plugins/auth/azure.ts
+++ b/src/lib/plugins/auth/azure.ts
@@ -4,12 +4,17 @@ import type { AuthPlugin } from "../types";
 export const azurePlugin: AuthPlugin = {
   id: "azure",
   name: "Azure AD",
-  getProvider: () =>
-    MicrosoftEntraID({
-      clientId: process.env.AZURE_AD_CLIENT_ID!,
-      clientSecret: process.env.AZURE_AD_CLIENT_SECRET!,
-      issuer: process.env.AZURE_AD_TENANT_ID 
+  getProvider: () => {
+    if (!process.env.AZURE_AD_CLIENT_ID || !process.env.AZURE_AD_CLIENT_SECRET) {
+      console.warn("Missing AZURE_AD_CLIENT_ID or AZURE_AD_CLIENT_SECRET. Azure AD auth provider disabled.");
+      return null;
+    }
+    return MicrosoftEntraID({
+      clientId: process.env.AZURE_AD_CLIENT_ID,
+      clientSecret: process.env.AZURE_AD_CLIENT_SECRET,
+      issuer: process.env.AZURE_AD_TENANT_ID
         ? `https://login.microsoftonline.com/${process.env.AZURE_AD_TENANT_ID}/v2.0`
         : undefined,
-    }),
+    });
+  },
 };

--- a/src/lib/plugins/auth/github.ts
+++ b/src/lib/plugins/auth/github.ts
@@ -4,10 +4,14 @@ import type { AuthPlugin } from "../types";
 export const githubPlugin: AuthPlugin = {
   id: "github",
   name: "GitHub",
-  getProvider: () =>
-    GitHub({
-      clientId: process.env.GITHUB_CLIENT_ID!,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+  getProvider: () => {
+    if (!process.env.GITHUB_CLIENT_ID || !process.env.GITHUB_CLIENT_SECRET) {
+      console.warn("Missing GITHUB_CLIENT_ID or GITHUB_CLIENT_SECRET. GitHub auth provider disabled.");
+      return null;
+    }
+    return GitHub({
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
       profile(profile) {
         return {
           id: profile.id.toString(),
@@ -18,5 +22,6 @@ export const githubPlugin: AuthPlugin = {
           githubUsername: profile.login, // Immutable GitHub username for contributor attribution
         };
       },
-    }),
+    });
+  },
 };

--- a/src/lib/plugins/auth/google.ts
+++ b/src/lib/plugins/auth/google.ts
@@ -4,9 +4,14 @@ import type { AuthPlugin } from "../types";
 export const googlePlugin: AuthPlugin = {
   id: "google",
   name: "Google",
-  getProvider: () =>
-    Google({
-      clientId: process.env.GOOGLE_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
+  getProvider: () => {
+    if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
+      console.warn("Missing GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET. Google auth provider disabled.");
+      return null;
+    }
+    return Google({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    });
+  },
 };

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -10,7 +10,7 @@ export interface AuthPlugin {
   /**
    * Returns the NextAuth provider configuration
    */
-  getProvider: () => NextAuthConfig["providers"][number];
+  getProvider: () => NextAuthConfig["providers"][number] | null;
 }
 
 // ============================================


### PR DESCRIPTION
This pull request directly addresses issue #1025 where users hosting via Docker encounter a \Configuration\ error redirect upon logging in. 

The issue surfaces when users specify OAuth strategies (like github or google) in their \PCHAT_AUTH_PROVIDERS\ string but fail to provide the corresponding client IDs and secrets in their environment variables. NextAuth responds to the empty strings by throwing a strict configuration error, disabling the authentication interface entirely—including the standard working email/credentials mechanism.

To fix this, the OAuth provider plugin loaders natively check if their respective environment keys are present before attempting initialization. If they are missing, it emits a setup warning in the console but safely returns a null provider that filters gracefully. This guarantees NextAuth functions securely with the remaining active providers without entering a failure crash loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced error handling across Apple, Azure, GitHub, and Google authentication providers to validate required credentials at runtime. Providers now gracefully disable with informative warning messages if environment variables are missing, improving reliability and preventing authentication failures from incomplete configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->