### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+ignore_format = true
+trim_trailing_whitespace = false


### PR DESCRIPTION

### 📝 Why is this useful?
Currently, the repository does not have an .editorconfig file.

This PR adds a standard .editorconfig to enforce foundational coding styles across different editors and IDEs (indentations, newlines, whitespace). This makes the open-source contributor experience smoother and avoids whitespace/line-ending differences in future Pull Requests.

### 🛠️ Key Changes
- ✅ Added .editorconfig setting default root styles (indent_size = 2, end_of_line = lf, etc.).