### PR TITLE
Fix local Docker startup loop and supervisorctl bootstrap issues

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -186,7 +186,7 @@ Build and run locally:
 
 ```bash
 docker build -f docker/Dockerfile -t prompts.chat .
-docker run -p 4444:3000 -v prompts-data:/data prompts.chat
+docker run --name prompts_library -p 4444:3000 -v prompts-data:/data prompts.chat
 ```
 
 ## Health Check

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,7 +31,8 @@ RUN mkdir -p /data/postgres /data/app && chown -R postgres:postgres /data/postgr
 # Copy bootstrap scripts
 COPY docker/bootstrap.sh /bootstrap.sh
 COPY docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-RUN chmod +x /bootstrap.sh
+# Fix Windows CRLF so /bootstrap.sh can run in Linux containers.
+RUN sed -i 's/\r$//' /bootstrap.sh && chmod +x /bootstrap.sh
 
 # Environment defaults
 ENV NODE_ENV=production

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -149,7 +149,8 @@ fi
 # Wait for supervisord socket to be ready
 echo "▶ Waiting for supervisord..."
 for i in $(seq 1 30); do
-    if supervisorctl -c /etc/supervisor/conf.d/supervisord.conf status >/dev/null 2>&1; then
+    # nextjs starts later, so only check the postgres program here.
+    if supervisorctl -c /etc/supervisor/conf.d/supervisord.conf status postgresql | grep -q "RUNNING"; then
         echo "✓ Supervisord is ready"
         break
     fi
@@ -164,12 +165,15 @@ done
 echo "▶ Starting Next.js..."
 supervisorctl -c /etc/supervisor/conf.d/supervisord.conf start nextjs
 
+# Display host port first (for using in browser) when provided (for -p host:container mappings).
+DISPLAY_PORT="${HOST_PORT:-${PORT:-80}}"
+
 echo ""
 echo "╔═══════════════════════════════════════════════════════════════╗"
 echo "║                                                               ║"
 echo "║   ✅ prompts.chat is running!                                 ║"
 echo "║                                                               ║"
-echo "║   🌐 Open http://localhost:${PORT:-80} in your browser            ║"
+echo "║   🌐 Open http://localhost:${DISPLAY_PORT} in your browser            ║"
 echo "║                                                               ║"
 echo "╚═══════════════════════════════════════════════════════════════╝"
 echo ""

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,9 +1,22 @@
+# Local socket used by supervisorctl.
+[unix_http_server]
+file=/tmp/supervisor.sock
+chmod=0700
+
 [supervisord]
 nodaemon=true
 user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 childlogdir=/var/log/supervisor
+
+# Required RPC interface for supervisorctl commands.
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
+
+# Tell supervisorctl where to connect.
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
 
 [program:postgresql]
 command=/usr/lib/postgresql/15/bin/postgres -D /data/postgres


### PR DESCRIPTION
## Description

This PR fixes local Docker startup issues encountered on first container launch.

Main updates:
- Fixed `supervisorctl` readiness check in `docker/bootstrap.sh` to wait for `postgresql` running state (instead of a generic status check that could loop).
- Added Supervisor control socket/RPC configuration in `docker/supervisord.conf` so `supervisorctl` can connect reliably.
- Fixed Windows CRLF compatibility in `docker/Dockerfile` by normalizing `/bootstrap.sh` line endings before execution.
- Improved startup message in `docker/bootstrap.sh` to show a host-usable port (`HOST_PORT` fallback).

Small Changes:
- Updated `DOCKER.md` local run command to include a container name for easier local management.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Additional Notes

This is focused on local/self-hosted container behavior, especially Windows-based development flows.
Key issue addressed: startup loop around "starting supervisord" and `/bootstrap.sh` execution reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker command documentation to reference container naming.

* **New Features**
  * Docker containers now have assigned names for easier management.
  * Improved startup readiness checks for database services.
  * Enhanced port information display during container initialization.

* **Bug Fixes**
  * Fixed Windows line-ending compatibility in bootstrap process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->