### PR TITLE
fix(book-pdf): prevent missing CJK text in generated PDFs

### DIFF
--- a/scripts/generate-book-pdf.ts
+++ b/scripts/generate-book-pdf.ts
@@ -34,18 +34,27 @@ const TRIM_HEIGHT = '9in';
 const BLEED_WIDTH = '6.25in';  // 6 + 0.125*2
 const BLEED_HEIGHT = '9.25in'; // 9 + 0.125*2
 
+/**
+ * Interface representing a set of font families for different typographic roles.
+ */
 interface FontStacks {
   serif: string;
   sans: string;
   mono: string;
 }
 
+/**
+ * Default font stacks used for all locales unless overridden.
+ */
 const DEFAULT_FONT_STACKS: FontStacks = {
   serif: `'Palatino Linotype', 'Book Antiqua', Palatino, Georgia, 'Times New Roman', serif`,
   sans: `'Helvetica Neue', Helvetica, Arial, sans-serif`,
   mono: `'SF Mono', 'Monaco', 'Menlo', 'Inconsolata', 'Fira Code', 'Consolas', monospace`,
 };
 
+/**
+ * Locale-specific font stack overrides to improve rendering for CJK and other languages.
+ */
 const LOCALE_FONT_STACKS: Partial<Record<string, Partial<FontStacks>>> = {
   zh: {
     serif: `'Songti SC', 'STSong', 'Noto Serif CJK SC', 'Source Han Serif SC', serif`,
@@ -2165,9 +2174,8 @@ function convertLinksToEndnotes(html: string, messages: Record<string, unknown> 
 }
 
 /**
- * Generate the HTML document for PDF
+ * Map part slugs to message keys for translation
  */
-// Map part slugs to message keys for translation
 const PART_TRANSLATION_KEYS: Record<string, string> = {
   'Introduction': 'introduction',
   'Foundations': 'foundations',
@@ -2178,6 +2186,15 @@ const PART_TRANSLATION_KEYS: Record<string, string> = {
   'Use Cases': 'useCases',
   'Conclusion': 'conclusion',
 };
+
+/**
+ * Generate the HTML document for PDF
+ * 
+ * @param chapters - The array of processed chapters to include.
+ * @param locale - The locale string.
+ * @param messages - Translation messages for the document metadata and labels.
+ * @returns The final HTML document as a string.
+ */
 
 function generateHtmlDocument(chapters: ProcessedChapter[], locale: string, messages: Record<string, unknown> = {}): string {
   // Print version uses shorter printTitle, screen uses full title


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes in this PR -->

This MR fixes missing CJK(China, Japan, Korea) text in generated book PDFs.

The issue was that some Chinese text rendered correctly in HTML but disappeared in exported PDFs, especially in:
- section headings
- prompt/example blocks styled with `.prompt-code`
<img width="598" height="907" alt="image" src="https://github.com/user-attachments/assets/0e5f0dfc-d4cf-441f-8fd9-8b98bf4ad291" />

The root cause was that the generated print HTML relied on default Latin-oriented font stacks, and `.prompt-code` depended on a monospace stack that is often missing CJK coverage on local systems.

This change adds locale-aware font stacks for `zh`, `ja`, and `ko`, routes heading styles through a dedicated heading font, and makes `.prompt-code` use the locale sans stack for CJK locales instead of the monospace stack.

The fix is intentionally narrow:
- no component structure changes
- no PDF generation pipeline changes
- no global removal of monospace styles
- only locale-aware font selection in generated HTML/CSS
- 
## Further Suggestion
This PR proposal has good compatibility but does not use the mono fonts.
If still want to use mono font for the  prompt/example blocks styled with `.prompt-code`, could install the relevent CJK fonts on the local device.

## Testing

- Ran:

```bash
node --import tsx scripts/generate-book-pdf.ts zh --print
```

- Opened `public/book-pdf/book-zh-print.html` in Chrome and exported pages `14-15`
- Verified:
  - page 14 Chinese prompt/example text is visible
  - page 15 heading `提示词工程的发展历程` is visible
  - comparison blocks still render correctly
- Confirmed the exported PDF text layer also contains the expected Chinese text

## Type of Change

- [ x ] Bug fix
- [x] Documentation update
- [x] Other (please describe):

---

## ⚠️ Want to Add a New Prompt?

**Please don't edit `prompts.csv` directly!**

Instead, visit **[prompts.chat](https://prompts.chat)** and:

1. **Login with GitHub** - Click the login button and authenticate with your GitHub account
2. **Create your prompt** - Use the prompt editor to add your new prompt
3. **Submit** - Your prompt will be reviewed and a [GitHub Action](https://github.com/f/prompts.chat/actions/workflows/update-contributors.yml) will automatically create a commit on your behalf

This ensures proper attribution, formatting, and keeps the repository in sync. You'll also appear on the [Contributors page](https://github.com/f/prompts.chat/graphs/contributors)!

---

## Additional Notes

<!-- Any additional context or screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Implemented locale-aware font selection for PDF output to better match language typography.
  * Headings now use a dedicated heading font for more consistent titles and TOC appearance.
  * Prompt/code blocks use a designated prompt font for improved readability.
  * Improved support for CJK languages and adjusted heading letter-spacing for better visual balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->