### PR TITLE
fix: resolve ESLint no-explicit-any errors in prompts.json route

### DIFF
--- a/src/app/prompts.json/route.ts
+++ b/src/app/prompts.json/route.ts
@@ -190,14 +190,14 @@ export async function GET(request: NextRequest) {
           identifier: getUserIdentifier(prompt.author),
           verified: prompt.author.verified,
         },
-        contributors: prompt.contributors.map((c: any) => ({
+        contributors: prompt.contributors.map((c: { username: string; name: string | null; avatar: string | null; githubUsername: string | null; verified: boolean }) => ({
           username: c.username,
           name: c.name,
           avatar: c.avatar,
           identifier: getUserIdentifier(c),
           verified: c.verified,
         })),
-        tags: prompt.tags.map((pt: any) => ({
+        tags: prompt.tags.map((pt: { tag: { id: string; name: string; slug: string; color: string | null } }) => ({
           id: pt.tag.id,
           name: pt.tag.name,
           slug: pt.tag.slug,


### PR DESCRIPTION
## Summary

Fixes 2 ESLint `no-explicit-any` errors in `src/app/prompts.json/route.ts` that caused CI lint failure after #1086 merge.

## Changes

```diff
- contributors: prompt.contributors.map((c: any) => ({
+ contributors: prompt.contributors.map((c: { username: string; name: string | null; avatar: string | null; githubUsername: string | null; verified: boolean }) => ({

- tags: prompt.tags.map((pt: any) => ({
+ tags: prompt.tags.map((pt: { tag: { id: string; name: string; slug: string; color: string | null } }) => ({
```

## Verification

- `npx eslint .` → 0 errors, 208 warnings (all pre-existing)
- `npx tsc --noEmit` → 0 errors on this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety and code maintainability through enhanced type annotations in data mapping processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->