### PR TITLE
Fix Docker bootstrap: supervisord socket not configured

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -146,23 +146,27 @@ if [ ! -f "$SEED_MARKER" ]; then
     fi
 fi
 
-# Wait for supervisord socket to be ready
+# Wait for supervisord to be ready
 echo "▶ Waiting for supervisord..."
 for i in $(seq 1 30); do
-    if supervisorctl -c /etc/supervisor/conf.d/supervisord.conf status >/dev/null 2>&1; then
+    if kill -0 $SUPERVISOR_PID 2>/dev/null && [ -S /var/run/supervisor.sock ]; then
         echo "✓ Supervisord is ready"
         break
     fi
+    if ! kill -0 $SUPERVISOR_PID 2>/dev/null; then
+        echo "✗ Supervisord process died"
+        exit 1
+    fi
     if [ $i -eq 30 ]; then
-        echo "✗ Supervisord failed to start"
+        echo "✗ Supervisord socket not available after 30s"
         exit 1
     fi
     sleep 1
 done
 
-# Start Next.js
+# Start Next.js via supervisorctl
 echo "▶ Starting Next.js..."
-supervisorctl -c /etc/supervisor/conf.d/supervisord.conf start nextjs
+supervisorctl start nextjs
 
 echo ""
 echo "╔═══════════════════════════════════════════════════════════════╗"

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,3 +1,13 @@
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [supervisord]
 nodaemon=true
 user=root


### PR DESCRIPTION
## Summary

- **supervisord.conf** was missing `[unix_http_server]`, `[supervisorctl]`, and `[rpcinterface:supervisor]` sections, so the Unix socket (`/var/run/supervisor.sock`) was never created
- The bootstrap readiness check (`supervisorctl status`) always returned a non-zero exit code, causing the container to exit with *"Supervisord failed to start"*
- This made the Docker image unusable — the container would never reach the Next.js startup phase

## Changes

- Add missing `[unix_http_server]`, `[supervisorctl]`, and `[rpcinterface:supervisor]` sections to `supervisord.conf`
- Improve bootstrap readiness check to verify both the supervisord process (via PID) and the socket file
- Add early exit with clear error message if the supervisord process dies unexpectedly
- Simplify `supervisorctl` calls (explicit config path no longer needed since socket is now properly configured)

## Test plan

- [x] Rebuild Docker image with updated files
- [x] Run container and verify supervisord starts with socket
- [x] Verify PostgreSQL and Next.js both enter RUNNING state
- [x] Confirm full startup sequence completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker container initialization with enhanced supervisord health verification. Updated startup checks now validate running process status and socket file availability before proceeding with application launch. Refined supervisord configuration with improved process control and inter-process communication mechanisms for more reliable container startup and overall service management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->