### PR TITLE
feat: Add support for running prompts on Netlify Agent Runners

### DIFF
--- a/packages/prompts.chat/src/cli/platforms.ts
+++ b/packages/prompts.chat/src/cli/platforms.ts
@@ -31,6 +31,7 @@ export const codePlatforms: Platform[] = [
   { id: "goose", name: "Goose", baseUrl: "goose://recipe", isDeeplink: true },
   { id: "github-copilot", name: "GitHub Copilot Chat", baseUrl: "https://github.com/copilot" },
   { id: "github-copilot-agents", name: "GitHub Copilot Agents", baseUrl: "https://github.com/copilot/agents" },
+  { id: "netlify", name: "Netlify", baseUrl: "https://app.netlify.com/run" },
   { id: "bolt", name: "Bolt", baseUrl: "https://bolt.new" },
   { id: "lovable", name: "Lovable", baseUrl: "https://lovable.dev" },
   { id: "v0", name: "v0", baseUrl: "https://v0.dev/chat" },
@@ -103,6 +104,8 @@ export function buildUrl(
       return `${baseUrl}/?prompt=${encoded}`;
     case "lovable":
       return `${baseUrl}/?autosubmit=true#prompt=${encoded}`;
+    case "netlify":
+      return `${baseUrl}?prompt=${encoded}&ref=prompts-chat`;
     case "mistral":
       return `${baseUrl}?q=${encoded}`;
     case "perplexity":

--- a/packages/raycast-extension/src/utils.ts
+++ b/packages/raycast-extension/src/utils.ts
@@ -193,6 +193,12 @@ export const codePlatforms: Platform[] = [
     supportsQuerystring: true,
   },
   {
+    id: "netlify",
+    name: "Netlify",
+    baseUrl: "https://app.netlify.com/run",
+    supportsQuerystring: true,
+  },
+  {
     id: "bolt",
     name: "Bolt",
     baseUrl: "https://bolt.new",
@@ -278,6 +284,8 @@ export function buildUrl(
       return `${baseUrl}/?prompt=${encoded}`;
     case "lovable":
       return `${baseUrl}/?autosubmit=true#prompt=${encoded}`;
+    case "netlify":
+      return `${baseUrl}?prompt=${encoded}&ref=prompts-chat`;
     case "mistral":
       return `${baseUrl}?q=${encoded}`;
     case "perplexity":

--- a/src/components/prompts/run-prompt-button.tsx
+++ b/src/components/prompts/run-prompt-button.tsx
@@ -91,6 +91,7 @@ const codePlatforms: Platform[] = [
       { name: "Copilot Agents", baseUrl: "https://github.com/copilot/agents" },
     ],
   },
+  { id: "netlify", name: "Netlify", baseUrl: "https://app.netlify.com/run" },
   { id: "bolt", name: "Bolt", baseUrl: "https://bolt.new" },
   { id: "lovable", name: "Lovable", baseUrl: "https://lovable.dev" },
   { id: "v0", name: "v0", baseUrl: "https://v0.dev/chat" },
@@ -173,6 +174,8 @@ function buildUrl(platformId: string, baseUrl: string, promptText: string, promp
       return `${baseUrl}/?prompt=${encoded}`;
     case "lovable":
       return `${baseUrl}/?autosubmit=true#prompt=${encoded}`;
+    case "netlify":
+      return `${baseUrl}?prompt=${encoded}&ref=prompts-chat`;
     case "mistral":
       return `${baseUrl}?q=${encoded}`;
     case "perplexity":


### PR DESCRIPTION
## Description

Netlify supports creating new projects or running prompts on existing ones using Claude Code, Codex CLI, or Gemini CLI agents. This link will open them up directly into a flow where the user can review and decide which path to take (new project or existing one) and let it rip.



## Type of Change

- [ ] Bug fix
- [ ] Documentation update
- [x] Other (please describe):

---

## Additional Notes

Here's an example of a url that this would trigger: https://app.netlify.com/run?prompt=hello,%20prompts.chat!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Netlify as a supported code platform, enabling users to run prompts directly on Netlify across multiple integration points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->