### PR TITLE
fix(security): Security Report Wiro `inputImageUrl` Blind SSRF

### DIFF
--- a/src/lib/plugins/media-generators/wiro.ts
+++ b/src/lib/plugins/media-generators/wiro.ts
@@ -185,12 +185,9 @@ export const wiroGeneratorPlugin: MediaGeneratorPlugin = {
     }
 
     if (request.inputImageUrl) {
-      // Fetch the image and add it to the form
-      const imageResponse = await fetch(request.inputImageUrl);
-      if (imageResponse.ok) {
-        const imageBlob = await imageResponse.blob();
-        formData.append("inputImage", imageBlob, "input.jpg");
-      }
+      // Pass the URL to Wiro instead of fetching server-side to avoid SSRF.
+      // Wiro's API natively supports inputImageUrl for fileinput parameters.
+      formData.append("inputImageUrl", request.inputImageUrl);
     }
 
     const response = await fetch(url, {


### PR DESCRIPTION
# Security Report — Wiro `inputImageUrl` Blind SSRF

**Date:** 2026-03-25  
**Severity:** Critical  
**Status:** Fixed  
**Affected path:** `POST /api/media-generate` → `src/lib/plugins/media-generators/wiro.ts`

---

## Summary

The Wiro plugin performed `fetch(request.inputImageUrl)` server-side with a user-controlled URL, then uploaded the fetched bytes to Wiro as multipart `inputImage`. This is a **blind SSRF** — the response body is not returned to the attacker, but the server-side fetch still enables internal network probing, timing attacks, and out-of-band exfiltration via Wiro.

**Reachability:** The stock frontend does not wire up `inputImageUrl`, but any authenticated user can exploit it via direct `POST /api/media-generate` with crafted JSON.

---

## Vulnerable Code

`src/lib/plugins/media-generators/wiro.ts`:

```ts
if (request.inputImageUrl) {
  const imageResponse = await fetch(request.inputImageUrl);  // SSRF sink
  if (imageResponse.ok) {
    const imageBlob = await imageResponse.blob();
    formData.append("inputImage", imageBlob, "input.jpg");
  }
}
```

---

## Fix: Use Wiro's Native `inputImageUrl` Parameter

The server never needed to fetch the image. Per [Wiro Model Parameters docs](https://wiro.ai/docs/model-parameters), any `fileinput` parameter supports a `{id}Url` suffix to pass a URL string instead of a file blob:

> **Tip:** For `fileinput` and `multifileinput` parameters, use the `{id}Url` suffix to send URLs (e.g., `inputImageUrl`).

By passing the URL directly to Wiro via `formData.append("inputImageUrl", ...)`, the fetch responsibility shifts to Wiro's infrastructure, completely eliminating the server-side SSRF.

### Why this is the ideal fix

1. **Zero server-side fetch** — no outbound request to user-controlled URLs
2. **No SSRF hardening needed** — no private IP blocking, DNS rebinding defenses, or redirect handling required
3. **Feature preserved** — reference-image generation continues to work
4. **Simpler code** — one `formData.append` replaces fetch + blob conversion

### Why other approaches are inferior

| Approach | Problem |
|----------|---------|
| Remove `inputImageUrl` entirely | Kills a useful feature the API supports natively |
| Add `isPrivateUrl()` guard | Bypassable via DNS rebinding, IPv4-mapped IPv6! Since its only used for webhook for the admin notification, I dont wanna waste my time to fix this. It's a lot of work to do|



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined image processing in Wiro media generator by optimizing how image URLs are handled, reducing server-side operations for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->