### PR TITLE
fix(security): Credit Deduction TOCTOU Race Condition

### DIFF
--- a/prisma/migrations/20260325164300_add_credits_non_negative_check/migration.sql
+++ b/prisma/migrations/20260325164300_add_credits_non_negative_check/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: Add CHECK constraint to prevent negative generation credits
+ALTER TABLE "users" ADD CONSTRAINT "credits_non_negative" CHECK ("generationCreditsRemaining" >= 0);

--- a/src/app/api/media-generate/route.ts
+++ b/src/app/api/media-generate/route.ts
@@ -50,35 +50,6 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    // Check user's credits and flagged status
-    const user = await db.user.findUnique({
-      where: { id: session.user.id },
-      select: {
-        generationCreditsRemaining: true,
-        flagged: true,
-      },
-    });
-
-    if (!user) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
-
-    // Block flagged users
-    if (user.flagged) {
-      return NextResponse.json(
-        { error: "Your account has been flagged. Media generation is disabled." },
-        { status: 403 }
-      );
-    }
-
-    // Check credits
-    if (user.generationCreditsRemaining <= 0) {
-      return NextResponse.json(
-        { error: "No generation credits remaining. Credits reset daily." },
-        { status: 403 }
-      );
-    }
-
     const body = await request.json();
     const { prompt, model, provider, type, inputImageUrl, resolution, aspectRatio } = body;
 
@@ -105,24 +76,60 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const task = await plugin.startGeneration({
-      prompt,
-      model,
-      type,
-      inputImageUrl,
-      resolution,
-      aspectRatio,
-    });
-
-    // Deduct one credit after successful generation start
-    await db.user.update({
-      where: { id: session.user.id },
+    // Atomic conditional decrement: check credits, flagged status, and deduct
+    // in a single SQL statement to prevent TOCTOU race conditions.
+    const result = await db.user.updateMany({
+      where: {
+        id: session.user.id,
+        flagged: false,
+        generationCreditsRemaining: { gt: 0 },
+      },
       data: {
-        generationCreditsRemaining: {
-          decrement: 1,
-        },
+        generationCreditsRemaining: { decrement: 1 },
       },
     });
+
+    if (result.count === 0) {
+      // Determine the specific reason for rejection
+      const user = await db.user.findUnique({
+        where: { id: session.user.id },
+        select: { flagged: true, generationCreditsRemaining: true },
+      });
+
+      if (!user) {
+        return NextResponse.json({ error: "User not found" }, { status: 404 });
+      }
+      if (user.flagged) {
+        return NextResponse.json(
+          { error: "Your account has been flagged. Media generation is disabled." },
+          { status: 403 }
+        );
+      }
+      return NextResponse.json(
+        { error: "No generation credits remaining. Credits reset daily." },
+        { status: 403 }
+      );
+    }
+
+    // Credit already deducted — now call the external provider
+    let task;
+    try {
+      task = await plugin.startGeneration({
+        prompt,
+        model,
+        type,
+        inputImageUrl,
+        resolution,
+        aspectRatio,
+      });
+    } catch (generationError) {
+      // Refund the credit on generation failure
+      await db.user.update({
+        where: { id: session.user.id },
+        data: { generationCreditsRemaining: { increment: 1 } },
+      });
+      throw generationError;
+    }
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
# Security Report: Credit Deduction TOCTOU Race Condition

**Severity:** High  
**Category:** CWE-367 — Time-of-Check Time-of-Use Race Condition  
**Affected Endpoint:** `POST /api/media-generate`  
**File:** `src/app/api/media-generate/route.ts`  

 CVSS v3.1 Score: 6.5 (Medium)

Vector:`AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N`

---

## Executive Summary

The media generation endpoint contains a Time-of-Check Time-of-Use (TOCTOU) race condition in its credit deduction logic. The credit balance is **read and checked** in one database query, then **decremented** in a separate query after a potentially slow external API call. An attacker with a single remaining credit can fire multiple concurrent requests that all pass the balance check before any decrement occurs, resulting in unlimited free media generations.

---

## Vulnerable Code Flow

### Step 1 — CHECK (Lines 54–75)

```typescript
// L54-60: Read the credit balance
const user = await db.user.findUnique({
  where: { id: session.user.id },
  select: { generationCreditsRemaining: true, flagged: true },
});

// L75: Authorize based on stale snapshot
if (user.generationCreditsRemaining <= 0) {
  return NextResponse.json({ error: "..." }, { status: 403 });
}
```

### Step 2 — RACE WINDOW (Lines 82–115)

```typescript
// L82-90:  Request body parsing
// L92-106: Plugin resolution and validation
// L108-115: External network call to Fal.ai / Wiro.ai (seconds of latency)
const task = await plugin.startGeneration({ ... });
```

### Step 3 — USE / DECREMENT (Lines 118–125)

```typescript
// L118-125: Decrement credit — far too late
await db.user.update({
  where: { id: session.user.id },
  data: { generationCreditsRemaining: { decrement: 1 } },
});
```

---

## Race Window Analysis

The gap between CHECK and DECREMENT spans:

| Phase | Duration | What Happens |
|-------|----------|-------------|
| Body parsing + validation | ~1–5 ms | JSON parse, field presence checks |
| Plugin resolution | ~1 ms | Map lookup |
| **External API call** | **200 ms – 10+ sec** | Network round-trip to Fal.ai/Wiro.ai queue API |
| **Total window** | **~200 ms – 10+ sec** | All concurrent requests read stale balance |

The external API call (`plugin.startGeneration()`) is the critical amplifier — it creates a multi-second window during which the credit balance in the database remains unchanged.

---

## Exploitation Scenario

**Precondition:** Attacker has exactly 1 credit remaining.

```
Time   Request A                  Request B                  DB State
─────  ────────────────────────   ────────────────────────   ────────
T+0    READ credits = 1 ✓         -                          credits = 1
T+1    -                          READ credits = 1 ✓         credits = 1
T+2    startGeneration() →        startGeneration() →        credits = 1
       (waiting for Fal.ai)       (waiting for Fal.ai)
T+3s   ← response                 ← response                credits = 1
T+3s   DECREMENT → credits = 0   DECREMENT → credits = -1   credits = -1
```

**Result:** 2 generations consumed with 1 credit. Scale to N concurrent requests for N generations with 1 credit.

### Practical Attack

```bash
# Fire 50 concurrent requests with a single credit
for i in $(seq 1 50); do
  curl -s -X POST https://target/api/media-generate \
    -H "Cookie: session=..." \
    -H "Content-Type: application/json" \
    -d '{"prompt":"test","model":"...","provider":"fal","type":"image"}' &
done
wait
```

---

## Missing Safeguards

| Safeguard | Present? | Details |
|-----------|----------|---------|
| Database transaction wrapping read+decrement | ❌ | No `$transaction` usage |
| Row-level lock (`SELECT ... FOR UPDATE`) | ❌ | Not used anywhere in codebase |
| Atomic conditional update (`WHERE credits > 0`) | ❌ | Read and write are separate |
| `CHECK` constraint on column | ❌ | No CHECK constraints in any migration |
| Rate limiting on endpoint | ❌ | Rate limiters only exist for MCP tools |
| Middleware-level throttle | ❌ | No `middleware.ts` exists |

---

## Database Schema Context

```prisma
// prisma/schema.prisma
model User {
  generationCreditsRemaining Int @default(3)
  dailyGenerationLimit       Int @default(3)
  // No @db.Check constraint, no trigger, no guard
}
```

Prisma's `{ decrement: 1 }` compiles to:

```sql
UPDATE "users" 
SET "generationCreditsRemaining" = "generationCreditsRemaining" - 1 
WHERE "id" = $1;
```

This is **atomically correct** (no lost updates) but **logically insufficient** — PostgreSQL will happily set the value to `-49` when 50 concurrent requests each decrement from 1.

---

## All Access Patterns for `generationCreditsRemaining`

| Location | Operation | Context |
|----------|-----------|---------|
| `media-generate/route.ts` L57 | `findUnique` (read) | POST — credit check |
| `media-generate/route.ts` L26 | `findUnique` (read) | GET — UI display |
| `media-generate/route.ts` L121 | `update` decrement | POST — deduction |
| `cron/reset-credits/route.ts` L40 | Raw SQL bulk SET | Daily reset cron |
| `admin/users/[id]/route.ts` L60 | `update` direct SET | Admin manual override |

---

## Recommended Fix

### Primary Fix — Atomic Conditional Decrement (Before Generation)

Replace the three-step read → check → decrement with a single atomic conditional update **before** calling the external API:

```typescript
// BEFORE calling startGeneration — atomic check + decrement
const result = await db.user.updateMany({
  where: {
    id: session.user.id,
    generationCreditsRemaining: { gt: 0 },
    flagged: false,
  },
  data: {
    generationCreditsRemaining: { decrement: 1 },
  },
});

if (result.count === 0) {
  return NextResponse.json(
    { error: "Insufficient credits or account flagged" },
    { status: 403 }
  );
}

// Credit is already deducted — now safe to call external API
try {
  const task = await plugin.startGeneration({ ... });
  // return success
} catch (error) {
  // Refund on failure
  await db.user.update({
    where: { id: session.user.id },
    data: { generationCreditsRemaining: { increment: 1 } },
  });
  throw error;
}
```

**Why this works:** The SQL becomes:

```sql
UPDATE "users" 
SET "generationCreditsRemaining" = "generationCreditsRemaining" - 1 
WHERE "id" = $1 
  AND "generationCreditsRemaining" > 0 
  AND "flagged" = false;
```

When two concurrent requests race, PostgreSQL's row-level locking ensures only one `UPDATE` matches the `WHERE credits > 0` condition when `credits = 1`. The second request sees `count = 0` and is rejected.

### Defense in Depth — Database CHECK Constraint

Add a migration as a safety net:

```sql
ALTER TABLE "users" 
ADD CONSTRAINT "credits_non_negative" 
CHECK ("generationCreditsRemaining" >= 0);
```

This makes any update that would drive credits negative fail at the database level, providing a backstop against any future code path that bypasses the application-level check.

### Recommendation

Apply **both** fixes:
1. Atomic conditional decrement with refund-on-failure (eliminates the TOCTOU)
2. Database CHECK constraint (defense in depth)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Implemented database constraint preventing generation credits from becoming negative
- Generation credit deduction now occurs atomically for improved reliability
- Failed generation attempts automatically refund deducted credits to users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->