### PR TITLE
Add SkillFlow to Integrations (Replaces #1100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ The setup wizard configures branding, theme, authentication (GitHub/Google/Azure
 ---
 
 ## 🔌 Integrations
+- [SkillFlow](https://github.com/rafsilva85/skillflow-mcp-server) - Open marketplace for AI agent skills and MCP servers.
+
 
 ### CLI
 ```bash


### PR DESCRIPTION
This replaces PR #1100. I've moved the SkillFlow entry out of the License section and into the Integrations section as requested by CodeRabbit in the previous PR review.

SkillFlow is an open marketplace for AI agent skills and MCP servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SkillFlow integration reference to project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->