### PR TITLE
fix: seed script fails due to missing content field

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,14 +3,15 @@ import bcrypt from "bcryptjs";
 
 const prisma = new PrismaClient();
 
-const PROMPTS_JSON_URL = "https://prompts.chat/prompts.json";
+const PROMPTS_JSON_URL = "https://prompts.chat/prompts.json?full_content=true";
 
-interface RemotePrompt {
+/** Raw shape returned by the remote API — content may be absent. */
+interface RemotePromptRaw {
   id: string;
   title: string;
   slug: string;
   description: string | null;
-  content: string;
+  content?: string;
   type: string;
   structuredFormat: string | null;
   mediaUrl: string | null;
@@ -52,11 +53,20 @@ interface RemotePrompt {
   }>;
 }
 
-interface RemotePromptsResponse {
-  count: number;
-  prompts: RemotePrompt[];
+/** Validated prompt with required content field. */
+type RemotePrompt = RemotePromptRaw & { content: string };
+
+/** Type guard that narrows a raw API prompt to a validated RemotePrompt. */
+function hasContent(prompt: RemotePromptRaw): prompt is RemotePrompt {
+  return typeof prompt.content === "string" && prompt.content.length > 0;
 }
 
+interface RemotePromptsResponse {
+  count: number;
+  prompts: RemotePromptRaw[];
+}
+
+/** Fetches all prompts from the remote prompts.chat API with full content. */
 async function fetchPrompts(): Promise<RemotePromptsResponse> {
   console.log(`📡 Fetching prompts from ${PROMPTS_JSON_URL}...`);
   const response = await fetch(PROMPTS_JSON_URL);
@@ -68,12 +78,13 @@ async function fetchPrompts(): Promise<RemotePromptsResponse> {
   return data;
 }
 
+/** Seeds the database with users, categories, tags, and prompts from prompts.chat. */
 async function main() {
   console.log("🌱 Seeding database from prompts.chat...");
 
   // Create admin user for assigning prompts
   const password = await bcrypt.hash("password123", 12);
-  
+
   const admin = await prisma.user.upsert({
     where: { email: "admin@prompts.chat" },
     update: {},
@@ -174,7 +185,7 @@ async function main() {
       userIdMap.set(username, admin.id);
       continue;
     }
-    
+
     const user = await prisma.user.upsert({
       where: { username },
       update: { name: author.name, avatar: author.avatar },
@@ -224,6 +235,13 @@ async function main() {
       YAML: "YAML",
     };
     const structuredFormat = remotePrompt.structuredFormat ? formatMap[remotePrompt.structuredFormat] : null;
+
+    // Skip prompts without content
+    if (!hasContent(remotePrompt)) {
+      console.warn(`⚠  Skipping prompt "${remotePrompt.title}" - no content`);
+      promptsSkipped++;
+      continue;
+    }
 
     // Check if prompt already exists
     const existingPrompt = await prisma.prompt.findFirst({
@@ -280,6 +298,16 @@ async function main() {
   }
 
   console.log(`✅ Created ${promptsCreated} prompts (${promptsSkipped} skipped)`);
+
+  // Fail-fast if no prompts were created — likely an upstream API regression
+  const total = promptsCreated + promptsSkipped;
+  if (total > 0 && promptsCreated === 0) {
+    throw new Error(
+      `Seeding failed: 0 prompts created out of ${total} (${promptsSkipped} skipped). ` +
+      `This likely indicates an upstream API regression — check that ${PROMPTS_JSON_URL} returns content.`
+    );
+  }
+
   console.log("\n🎉 Seeding complete!");
   console.log("\n📋 Test credentials (password: password123):");
   console.log("   Admin: admin@prompts.chat");


### PR DESCRIPTION

## Description

Fixes #1112

### Problem

`npm run db:seed` fails with `PrismaClientValidationError: Argument 'content' is missing` for every prompt. Result: 0 prompts created, all 1595 skipped.

The seed script fetches `https://prompts.chat/prompts.json` without the `?full_content=true` parameter. The `/prompts.json` API route only includes the `content` field when `full_content=true` is explicitly set — otherwise it returns only `contentPreview`.

### Changes

- Add `?full_content=true` to the fetch URL in `prisma/seed.ts`
- Make `content` optional in the `RemotePrompt` interface (defensive)
- Skip prompts without content with a warning instead of failing

### Result

- **Before:** Created 0 prompts (1595 skipped) with validation errors
- **After:** Created 1576 prompts (19 skipped — no content on remote)

## Type of Change

- [ X ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

---

## ⚠️ Want to Add a New Prompt?

**Please don't edit `prompts.csv` directly!**

Instead, visit **[prompts.chat](https://prompts.chat)** and:

1. **Login with GitHub** - Click the login button and authenticate with your GitHub account
2. **Create your prompt** - Use the prompt editor to add your new prompt
3. **Submit** - Your prompt will be reviewed and a [GitHub Action](https://github.com/f/prompts.chat/actions/workflows/update-contributors.yml) will automatically create a commit on your behalf

This ensures proper attribution, formatting, and keeps the repository in sync. You'll also appear on the [Contributors page](https://github.com/f/prompts.chat/graphs/contributors)!

---

## Additional Notes

<!-- Any additional context or screenshots -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incomplete or empty prompts are now skipped during data initialization, preventing creation of partial records and emitting warnings; seeding will fail if no prompts are successfully created after processing.

* **Chores**
  * Data requests updated to retrieve complete prompt content during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->