### PR TITLE
perf: add ISR to /prompts page

### DIFF
--- a/src/app/prompts/page.tsx
+++ b/src/app/prompts/page.tsx
@@ -16,6 +16,8 @@ import { isAISearchEnabled, semanticSearch } from "@/lib/ai/embeddings";
 import { isAIGenerationEnabled } from "@/lib/ai/generation";
 import config from "@/../prompts.config";
 
+export const revalidate = 60;
+
 export const metadata: Metadata = {
   title: "Prompts",
   description: "Browse and discover AI prompts",


### PR DESCRIPTION


Enable ISR with 60-second revalidation on the `/prompts` listing page.

This page has **no `auth()` dependency** (verified — it uses `unstable_cache` for all data fetching), receives high traffic, and currently has a **0% cache hit rate** with P75 latency of **269ms**.

## Changes

One line: `export const revalidate = 60` in `src/app/prompts/page.tsx`

## Expected impact

- ~99% cache hit rate (first request per 60s invokes function, rest served from ISR cache)
- P75 latency: 269ms → <5ms for cached requests
- Reduced function invocations, CPU, and origin transfer for this route