### PR TITLE
fix(cli): add missing full_content param to API URL

### DIFF
--- a/packages/prompts.chat/src/cli/api.ts
+++ b/packages/prompts.chat/src/cli/api.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 
-const PROMPTS_URL = 'https://prompts.chat/prompts.json';
+const PROMPTS_URL = 'https://prompts.chat/prompts.json?full_content=true';
 const CACHE_DIR = join(homedir(), '.prompts-chat');
 const CACHE_FILE = join(CACHE_DIR, 'prompts.json');
 

--- a/packages/prompts.chat/src/cli/components/PromptDetail.tsx
+++ b/packages/prompts.chat/src/cli/components/PromptDetail.tsx
@@ -77,7 +77,7 @@ export function PromptDetail({ prompt, onBack, onCopy }: PromptDetailProps) {
   const contentHeight = Math.max(terminalHeight - headerLines - footerLines, 5);
 
   useEffect(() => {
-    const vars = extractVariables(prompt.content);
+    const vars = extractVariables(prompt.content ?? '');
     setVariables(vars);
     
     const defaults: Record<string, string> = {};
@@ -90,7 +90,7 @@ export function PromptDetail({ prompt, onBack, onCopy }: PromptDetailProps) {
   const contentLines = useMemo(() => {
     if (!prompt) return [];
     // Parse escape sequences like \n
-    const parsedContent = prompt.content.replace(/\\n/g, '\n');
+    const parsedContent = (prompt.content ?? '').replace(/\\n/g, '\n');
     return wrapText(parsedContent, terminalWidth - 6);
   }, [prompt, terminalWidth]);
 
@@ -200,12 +200,12 @@ export function PromptDetail({ prompt, onBack, onCopy }: PromptDetailProps) {
         setCurrentVarIndex(0);
         setCurrentInput(variableValues[variables[0].name] || '');
       } else {
-        handleCopy(prompt.content);
+        handleCopy(prompt.content ?? '');
       }
     }
 
     if (input === 'C' && prompt) {
-      handleCopy(prompt.content);
+      handleCopy(prompt.content ?? '');
     }
 
     if (input === 'o' && prompt) {


### PR DESCRIPTION
## Summary

The CLI fetches `prompts.json` without the `?full_content=true` query parameter, so the API returns `contentPreview` instead of the full `content` field. This causes `PromptDetail` to crash with:

```
TypeError: Cannot read properties of undefined (reading 'replace')
```

## Changes

- **`packages/prompts.chat/src/cli/api.ts`**: Added `?full_content=true` to `PROMPTS_URL` (same fix that was already applied to `prisma/seed.ts` in commit e4686cb9)
- **`packages/prompts.chat/src/cli/components/PromptDetail.tsx`**: Added `?? ''` null coalescing guards on all `prompt.content` accesses as a safety net

## Test plan

- [x] Verified the seed script already uses `?full_content=true` as reference
- [ ] Run `npx prompts.chat` and select a prompt — should display content without crash

Closes #1107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stability issues when displaying prompts with missing or undefined content
* **Improvements**
  * Prompts now load with more complete content information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->