### PR TITLE
Add LM Studio import script for prompts.csv

### DIFF
--- a/scripts/import-to-lmstudio.py
+++ b/scripts/import-to-lmstudio.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Import prompts.csv into LM Studio as config presets.
+
+Usage:
+  python3 scripts/import-to-lmstudio.py              # import all prompts
+  python3 scripts/import-to-lmstudio.py --dev-only   # import only for_devs=TRUE
+  python3 scripts/import-to-lmstudio.py --dry-run    # preview without writing
+"""
+
+import csv
+import json
+import os
+import re
+import sys
+import argparse
+from pathlib import Path
+
+PRESETS_DIR = Path.home() / ".lmstudio" / "config-presets"
+CSV_PATH = Path(__file__).parent.parent / "prompts.csv"
+
+
+def slugify(text: str) -> str:
+    text = re.sub(r"[^\w\s-]", "", text).strip()
+    text = re.sub(r"[\s_-]+", "-", text)
+    return text[:60]
+
+
+def make_preset(act: str, prompt: str) -> dict:
+    return {
+        "identifier": f"@local:{slugify(act)}",
+        "name": act,
+        "changed": True,
+        "operation": {
+            "fields": [
+                {
+                    "key": "llm.prediction.systemPrompt",
+                    "value": prompt,
+                }
+            ]
+        },
+        "load": {"fields": []},
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Import prompts.chat CSV into LM Studio presets")
+    parser.add_argument("--dev-only", action="store_true", help="Only import for_devs=TRUE prompts")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be created without writing files")
+    args = parser.parse_args()
+
+    csv.field_size_limit(10_000_000)
+
+    prompts = []
+    with open(CSV_PATH, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            act = row.get("act", "").strip()
+            prompt = row.get("prompt", "").strip()
+            for_devs = row.get("for_devs", "").strip().upper()
+
+            if not act or not prompt:
+                continue
+            if args.dev_only and for_devs != "TRUE":
+                continue
+
+            prompts.append((act, prompt))
+
+    print(f"Found {len(prompts)} prompts to import")
+
+    if args.dry_run:
+        for act, prompt in prompts[:5]:
+            print(f"  • {act!r} → {slugify(act)}.preset.json")
+        if len(prompts) > 5:
+            print(f"  … and {len(prompts) - 5} more")
+        print("\n(dry-run: no files written)")
+        return
+
+    PRESETS_DIR.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    skipped = 0
+    seen_slugs: dict[str, int] = {}
+
+    for act, prompt in prompts:
+        slug = slugify(act)
+
+        # deduplicate: if slug collides, append a counter
+        if slug in seen_slugs:
+            seen_slugs[slug] += 1
+            slug = f"{slug}-{seen_slugs[slug]}"
+        else:
+            seen_slugs[slug] = 0
+
+        dest = PRESETS_DIR / f"{slug}.preset.json"
+
+        if dest.exists():
+            skipped += 1
+            continue
+
+        preset = make_preset(act, prompt)
+        dest.write_text(json.dumps(preset, indent=2, ensure_ascii=False), encoding="utf-8")
+        written += 1
+
+    print(f"Done: {written} presets written to {PRESETS_DIR}")
+    if skipped:
+        print(f"Skipped {skipped} (already existed — delete them first to re-import)")
+    print("\nRestart LM Studio (or switch presets panel) to see them.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `scripts/import-to-lmstudio.py` — a utility script that reads `prompts.csv` and writes each prompt as a config preset JSON file to `~/.lmstudio/config-presets/`
- Makes all 1645 community prompts available as system-prompt presets inside LM Studio (no API key or internet connection required)
- Supports `--dev-only` flag to import only `for_devs=TRUE` prompts, and `--dry-run` to preview without writing files

## Usage

```bash
python3 scripts/import-to-lmstudio.py              # import all prompts
python3 scripts/import-to-lmstudio.py --dev-only   # for_devs=TRUE only
python3 scripts/import-to-lmstudio.py --dry-run    # preview without writing
```

Then restart LM Studio — presets appear in the presets panel, each pre-loaded with the corresponding system prompt.

## Test plan

- [ ] Run `--dry-run` and verify expected preset names are printed
- [ ] Run without flags and verify files appear in `~/.lmstudio/config-presets/`
- [ ] Open LM Studio, check presets panel shows imported prompts
- [ ] Verify `--dev-only` only imports `for_devs=TRUE` rows
- [ ] Verify re-running skips existing files without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bulk-import tool to load prompts from CSV into LM Studio configuration presets
  * Includes filtering option for developer-only entries
  * Supports dry-run mode to preview changes before applying
  * Automatically handles naming conflicts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->