### PR TITLE
fix(docker): use the prebuilt image by default in compose

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -17,12 +17,12 @@ services:
       start_period: 10s
 
   app:
-    build:
-      context: .
-      dockerfile: docker/Dockerfile
-    # To use a pre-built image instead of building locally, comment out
-    # the 'build' block above and uncomment the line below:
-    # image: ghcr.io/f/prompts.chat:latest
+    image: ghcr.io/f/prompts.chat:latest
+    # To build locally instead of using the pre-built image, comment out
+    # the 'image' line above and uncomment the build block below:
+    # build:
+    #   context: .
+    #   dockerfile: docker/Dockerfile
     restart: unless-stopped
     ports:
       - "${PORT:-4444}:3000"


### PR DESCRIPTION
## Summary
- use the published `ghcr.io/f/prompts.chat:latest` image by default in `compose.yml`
- keep the local Dockerfile build path documented as an explicit opt-in block

## Why
The compose file currently builds the app image on first run. That makes self-hosting more fragile on small hosts because the initial Next.js/Docker build needs much more memory than running the already-built app. The repository already documents the pre-built GHCR image in the compose comments; this change makes that safer path the default while preserving the local build instructions for contributors.

## Validation
- `git diff --check -- compose.yml`
- static check that `compose.yml` uses `ghcr.io/f/prompts.chat:latest` and keeps the local `build` block commented as opt-in


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration to use a pre-built container image for streamlined deployment instead of building locally. Configuration can now be toggled more easily between image and build options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->