### PR TITLE
feat(auth): honour AUTH_OIDC/OAUTH_NAME and _LOGO env vars in login button

### DIFF
--- a/src/__tests__/lib/auth/provider-metadata.test.ts
+++ b/src/__tests__/lib/auth/provider-metadata.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { getProviderMetadata, getConfiguredProviderIds } from "@/lib/auth/provider-metadata";
 
+type ConfigParam = Parameters<typeof getConfiguredProviderIds>[0];
+
 describe("Provider Metadata", () => {
     const originalEnv = process.env;
 
@@ -107,15 +109,23 @@ describe("Provider Metadata", () => {
         it("should return providers array when configured", () => {
             const config = {
                 auth: { providers: ["github", "google", "oidc"], allowRegistration: false },
-            } as any;
+            } as unknown as ConfigParam;
 
             expect(getConfiguredProviderIds(config)).toEqual(["github", "google", "oidc"]);
+        });
+
+        it("should fallback to deprecated singular provider string if present", () => {
+            const config = {
+                auth: { provider: "github", allowRegistration: false },
+            } as unknown as ConfigParam;
+
+            expect(getConfiguredProviderIds(config)).toEqual(["github"]);
         });
 
         it("should default to credentials when providers array is empty", () => {
             const config = {
                 auth: { providers: [], allowRegistration: false },
-            } as any;
+            } as unknown as ConfigParam;
 
             expect(getConfiguredProviderIds(config)).toEqual(["credentials"]);
         });
@@ -123,7 +133,7 @@ describe("Provider Metadata", () => {
         it("should default to credentials when providers is not set", () => {
             const config = {
                 auth: { allowRegistration: false },
-            } as any;
+            } as unknown as ConfigParam;
 
             expect(getConfiguredProviderIds(config)).toEqual(["credentials"]);
         });

--- a/src/__tests__/lib/auth/provider-metadata.test.ts
+++ b/src/__tests__/lib/auth/provider-metadata.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getProviderMetadata, getConfiguredProviderIds } from "@/lib/auth/provider-metadata";
+
+describe("Provider Metadata", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    describe("getProviderMetadata", () => {
+        it("should return empty maps when no generic providers are requested", () => {
+            const result = getProviderMetadata(["github", "google"]);
+            expect(result.displayNames).toEqual({});
+            expect(result.logos).toEqual({});
+        });
+
+        it("should read OIDC display name and logo from env", () => {
+            process.env.AUTH_OIDC_NAME = "Corporate SSO";
+            process.env.AUTH_OIDC_LOGO = "https://example.com/logo.svg";
+
+            const result = getProviderMetadata(["github", "oidc"]);
+            expect(result.displayNames).toEqual({ oidc: "Corporate SSO" });
+            expect(result.logos).toEqual({ oidc: "https://example.com/logo.svg" });
+        });
+
+        it("should read OAuth display name and logo from env", () => {
+            process.env.AUTH_OAUTH_NAME = "Legacy IdP";
+            process.env.AUTH_OAUTH_LOGO = "https://idp.example.com/icon.png";
+
+            const result = getProviderMetadata(["oauth"]);
+            expect(result.displayNames).toEqual({ oauth: "Legacy IdP" });
+            expect(result.logos).toEqual({ oauth: "https://idp.example.com/icon.png" });
+        });
+
+        it("should return both OIDC and OAuth metadata when both are configured", () => {
+            process.env.AUTH_OIDC_NAME = "OIDC Provider";
+            process.env.AUTH_OIDC_LOGO = "https://oidc.example.com/logo.svg";
+            process.env.AUTH_OAUTH_NAME = "OAuth Provider";
+            process.env.AUTH_OAUTH_LOGO = "https://oauth.example.com/logo.svg";
+
+            const result = getProviderMetadata(["oidc", "oauth"]);
+            expect(result.displayNames).toEqual({
+                oidc: "OIDC Provider",
+                oauth: "OAuth Provider",
+            });
+            expect(result.logos).toEqual({
+                oidc: "https://oidc.example.com/logo.svg",
+                oauth: "https://oauth.example.com/logo.svg",
+            });
+        });
+
+        it("should omit name when env var is not set", () => {
+            process.env.AUTH_OIDC_LOGO = "https://example.com/logo.svg";
+            // AUTH_OIDC_NAME not set
+
+            const result = getProviderMetadata(["oidc"]);
+            expect(result.displayNames).toEqual({});
+            expect(result.logos).toEqual({ oidc: "https://example.com/logo.svg" });
+        });
+
+        it("should omit logo when env var is not set", () => {
+            process.env.AUTH_OIDC_NAME = "My Provider";
+            // AUTH_OIDC_LOGO not set
+
+            const result = getProviderMetadata(["oidc"]);
+            expect(result.displayNames).toEqual({ oidc: "My Provider" });
+            expect(result.logos).toEqual({});
+        });
+
+        it("should reject logo URLs with javascript: protocol", () => {
+            process.env.AUTH_OIDC_NAME = "Evil Provider";
+            process.env.AUTH_OIDC_LOGO = "javascript:alert('xss')";
+
+            const result = getProviderMetadata(["oidc"]);
+            expect(result.displayNames).toEqual({ oidc: "Evil Provider" });
+            expect(result.logos).toEqual({});
+        });
+
+        it("should reject logo URLs with data: protocol", () => {
+            process.env.AUTH_OIDC_LOGO = "data:image/svg+xml,<svg></svg>";
+
+            const result = getProviderMetadata(["oidc"]);
+            expect(result.logos).toEqual({});
+        });
+
+        it("should accept http:// logo URLs", () => {
+            process.env.AUTH_OIDC_LOGO = "http://internal.corp.com/logo.png";
+
+            const result = getProviderMetadata(["oidc"]);
+            expect(result.logos).toEqual({ oidc: "http://internal.corp.com/logo.png" });
+        });
+
+        it("should reject malformed URLs", () => {
+            process.env.AUTH_OIDC_LOGO = "not-a-url";
+
+            const result = getProviderMetadata(["oidc"]);
+            expect(result.logos).toEqual({});
+        });
+    });
+
+    describe("getConfiguredProviderIds", () => {
+        it("should return providers array when configured", () => {
+            const config = {
+                auth: { providers: ["github", "google", "oidc"], allowRegistration: false },
+            } as any;
+
+            expect(getConfiguredProviderIds(config)).toEqual(["github", "google", "oidc"]);
+        });
+
+        it("should default to credentials when providers array is empty", () => {
+            const config = {
+                auth: { providers: [], allowRegistration: false },
+            } as any;
+
+            expect(getConfiguredProviderIds(config)).toEqual(["credentials"]);
+        });
+
+        it("should default to credentials when providers is not set", () => {
+            const config = {
+                auth: { allowRegistration: false },
+            } as any;
+
+            expect(getConfiguredProviderIds(config)).toEqual(["credentials"]);
+        });
+    });
+});

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { getConfig } from "@/lib/config";
+import { getConfiguredProviderIds, getProviderMetadata } from "@/lib/auth/provider-metadata";
 import { AuthContent } from "@/components/auth/auth-content";
 
 export const metadata: Metadata = {
@@ -9,24 +10,14 @@ export const metadata: Metadata = {
   description: "Login to your account",
 };
 
-// Helper to get providers from config (supports both old `provider` and new `providers` array)
-function getProviders(config: Awaited<ReturnType<typeof getConfig>>): string[] {
-  if (config.auth.providers && config.auth.providers.length > 0) {
-    return config.auth.providers;
-  }
-  if (config.auth.provider) {
-    return [config.auth.provider];
-  }
-  return ["credentials"];
-}
-
 export default async function LoginPage() {
   const t = await getTranslations("auth");
   const config = await getConfig();
-  const providers = getProviders(config);
+  const providers = getConfiguredProviderIds(config);
   const hasCredentials = providers.includes("credentials");
   const hasOnlyCredentials = providers.length === 1 && hasCredentials;
   const useCloneBranding = config.homepage?.useCloneBranding ?? false;
+  const { displayNames, logos } = getProviderMetadata(providers);
 
   return (
     <div className="container flex min-h-[calc(100vh-6rem)] flex-col items-center justify-center py-8">
@@ -38,7 +29,7 @@ export default async function LoginPage() {
           </p>
         </div>
         <div className="border rounded-lg p-4">
-          <AuthContent providers={providers} mode="login" useCloneBranding={useCloneBranding} />
+          <AuthContent providers={providers} mode="login" useCloneBranding={useCloneBranding} providerDisplayNames={displayNames} providerLogos={logos} />
         </div>
         {hasCredentials && (
           <p className="text-center text-xs text-muted-foreground">

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getConfig } from "@/lib/config";
+import { getConfiguredProviderIds, getProviderMetadata } from "@/lib/auth/provider-metadata";
 import { AuthContent } from "@/components/auth/auth-content";
 
 export const metadata: Metadata = {
@@ -10,27 +11,18 @@ export const metadata: Metadata = {
   description: "Create a new account",
 };
 
-// Helper to get providers from config (supports both old `provider` and new `providers` array)
-function getProviders(config: Awaited<ReturnType<typeof getConfig>>): string[] {
-  if (config.auth.providers && config.auth.providers.length > 0) {
-    return config.auth.providers;
-  }
-  if (config.auth.provider) {
-    return [config.auth.provider];
-  }
-  return ["credentials"];
-}
-
 export default async function RegisterPage() {
   const t = await getTranslations("auth");
   const config = await getConfig();
-  const providers = getProviders(config);
+  const providers = getConfiguredProviderIds(config);
   const hasCredentials = providers.includes("credentials");
 
   // Block registration if disabled or credentials not enabled
   if (!hasCredentials || !config.auth.allowRegistration) {
     redirect("/login");
   }
+
+  const { displayNames, logos } = getProviderMetadata(providers);
 
   return (
     <div className="container flex min-h-[calc(100vh-6rem)] flex-col items-center justify-center py-8">
@@ -40,7 +32,7 @@ export default async function RegisterPage() {
           <p className="text-xs text-muted-foreground">{t("registerDescription")}</p>
         </div>
         <div className="border rounded-lg p-4">
-          <AuthContent providers={providers} mode="register" />
+          <AuthContent providers={providers} mode="register" providerDisplayNames={displayNames} providerLogos={logos} />
         </div>
         <p className="text-center text-xs text-muted-foreground">
           {t("hasAccount")}{" "}

--- a/src/components/auth/auth-content.tsx
+++ b/src/components/auth/auth-content.tsx
@@ -9,6 +9,8 @@ interface AuthContentProps {
   providers: string[];
   mode: "login" | "register";
   useCloneBranding?: boolean;
+  providerDisplayNames?: Record<string, string>;
+  providerLogos?: Record<string, string>;
 }
 
 const providerNames: Record<string, string> = {
@@ -19,7 +21,7 @@ const providerNames: Record<string, string> = {
   credentials: "Email",
 };
 
-export function AuthContent({ providers, mode, useCloneBranding = false }: AuthContentProps) {
+export function AuthContent({ providers, mode, useCloneBranding = false, providerDisplayNames, providerLogos }: AuthContentProps) {
   const t = useTranslations("auth");
   const hasCredentials = providers.includes("credentials");
   const oauthProviders = providers.filter((p) => p !== "credentials");
@@ -34,7 +36,8 @@ export function AuthContent({ providers, mode, useCloneBranding = false }: AuthC
             <OAuthButton
               key={provider}
               provider={provider}
-              providerName={providerNames[provider] || provider}
+              providerName={providerDisplayNames?.[provider] || providerNames[provider] || provider}
+              iconUrl={providerLogos?.[provider]}
             />
           ))}
           {hasGitHub && !useCloneBranding && (

--- a/src/components/auth/oauth-button.tsx
+++ b/src/components/auth/oauth-button.tsx
@@ -42,6 +42,7 @@ const providerIcons: Record<string, React.ReactNode> = {
 export function OAuthButton({ provider, providerName, iconUrl }: OAuthButtonProps) {
   const t = useTranslations("auth");
   const [isLoading, setIsLoading] = useState(false);
+  const [imgError, setImgError] = useState(false);
 
   const handleSignIn = async () => {
     setIsLoading(true);
@@ -64,11 +65,15 @@ export function OAuthButton({ provider, providerName, iconUrl }: OAuthButtonProp
     >
       {isLoading ? (
         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-      ) : iconUrl ? (
+      ) : iconUrl && !imgError ? (
         /* eslint-disable-next-line @next/next/no-img-element */
-        <img src={iconUrl} alt={providerName} className="mr-2 h-4 w-4 object-contain" />
-      ) : (
+        <img src={iconUrl} alt={providerName} className="mr-2 h-4 w-4 object-contain" onError={() => setImgError(true)} />
+      ) : providerIcons[provider] ? (
         <span className="mr-2">{providerIcons[provider]}</span>
+      ) : (
+        <span className="mr-2 flex h-4 w-4 items-center justify-center rounded bg-primary/10 text-[10px] font-bold text-primary">
+          {providerName.charAt(0).toUpperCase()}
+        </span>
       )}
       {t("signInWith", { provider: providerName })}
     </Button>

--- a/src/components/auth/oauth-button.tsx
+++ b/src/components/auth/oauth-button.tsx
@@ -10,6 +10,7 @@ import { analyticsAuth } from "@/lib/analytics";
 interface OAuthButtonProps {
   provider: string;
   providerName: string;
+  iconUrl?: string;
 }
 
 const providerIcons: Record<string, React.ReactNode> = {
@@ -38,7 +39,7 @@ const providerIcons: Record<string, React.ReactNode> = {
   ),
 };
 
-export function OAuthButton({ provider, providerName }: OAuthButtonProps) {
+export function OAuthButton({ provider, providerName, iconUrl }: OAuthButtonProps) {
   const t = useTranslations("auth");
   const [isLoading, setIsLoading] = useState(false);
 
@@ -63,6 +64,9 @@ export function OAuthButton({ provider, providerName }: OAuthButtonProps) {
     >
       {isLoading ? (
         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+      ) : iconUrl ? (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img src={iconUrl} alt={providerName} className="mr-2 h-4 w-4 object-contain" />
       ) : (
         <span className="mr-2">{providerIcons[provider]}</span>
       )}

--- a/src/lib/auth/provider-metadata.ts
+++ b/src/lib/auth/provider-metadata.ts
@@ -68,5 +68,8 @@ export function getConfiguredProviderIds(config: Awaited<ReturnType<typeof getCo
     if (config.auth.providers && config.auth.providers.length > 0) {
         return config.auth.providers;
     }
+    if (config.auth.provider && typeof config.auth.provider === "string") {
+        return [config.auth.provider];
+    }
     return ["credentials"];
 }

--- a/src/lib/auth/provider-metadata.ts
+++ b/src/lib/auth/provider-metadata.ts
@@ -1,0 +1,72 @@
+import type { getConfig } from "@/lib/config";
+
+/**
+ * Extracts display names and logo URLs for auth providers from environment variables.
+ *
+ * Standard providers (GitHub, Google, etc.) already have hardcoded names/icons in the UI.
+ * This function reads `AUTH_OIDC_NAME`, `AUTH_OIDC_LOGO`, `AUTH_OAUTH_NAME`, `AUTH_OAUTH_LOGO`
+ * so that the generic OIDC/OAuth providers can also display branded buttons.
+ *
+ * This runs server-side only (in Server Components) and passes the result as serializable props.
+ */
+
+// Map of provider env-var prefixes for generic providers
+const GENERIC_PROVIDER_ENV_MAP: Record<string, { nameVar: string; logoVar: string }> = {
+    oidc: { nameVar: "AUTH_OIDC_NAME", logoVar: "AUTH_OIDC_LOGO" },
+    oauth: { nameVar: "AUTH_OAUTH_NAME", logoVar: "AUTH_OAUTH_LOGO" },
+};
+
+export interface ProviderMetadata {
+    displayNames: Record<string, string>;
+    logos: Record<string, string>;
+}
+
+/**
+ * Validates that a URL uses a safe protocol (http or https).
+ * Prevents injection of javascript:, data:, or other dangerous URI schemes.
+ */
+function isSafeUrl(url: string): boolean {
+    try {
+        const parsed = new URL(url);
+        return parsed.protocol === "https:" || parsed.protocol === "http:";
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Builds provider display names and logos maps for the given provider IDs.
+ * Should be called from a Server Component where process.env is accessible.
+ */
+export function getProviderMetadata(providerIds: string[]): ProviderMetadata {
+    const displayNames: Record<string, string> = {};
+    const logos: Record<string, string> = {};
+
+    for (const id of providerIds) {
+        const envMapping = GENERIC_PROVIDER_ENV_MAP[id];
+        if (envMapping) {
+            const name = process.env[envMapping.nameVar];
+            const logo = process.env[envMapping.logoVar];
+
+            if (name) {
+                displayNames[id] = name;
+            }
+            if (logo && isSafeUrl(logo)) {
+                logos[id] = logo;
+            }
+        }
+    }
+
+    return { displayNames, logos };
+}
+
+/**
+ * Helper to get configured provider IDs from config.
+ * Shared by both login and register pages.
+ */
+export function getConfiguredProviderIds(config: Awaited<ReturnType<typeof getConfig>>): string[] {
+    if (config.auth.providers && config.auth.providers.length > 0) {
+        return config.auth.providers;
+    }
+    return ["credentials"];
+}


### PR DESCRIPTION
## Description

Adds support for displaying **custom provider names and logos** on the SSO login buttons for generic OIDC and OAuth providers, using existing AUTH_OIDC_NAME, AUTH_OIDC_LOGO, AUTH_OAUTH_NAME, and AUTH_OAUTH_LOGO environment variables.

### Problem

The generic OIDC and OAuth plugins already read the name and logo environment variables and pass them to Auth.js. However, Auth.js strips the logo from its providers endpoint response, and the login page UI uses a hardcoded provider name/icon map — meaning the OIDC button would show as **"Sign in with oidc"** with no logo, regardless of what's configured.

### Solution

Read the name and logo env vars server-side in the login/register page components (which are Next.js Server Components with access to process.env) and pass them as props down to the OAuth button. Standard providers (GitHub, Google, Azure, Apple) are unaffected — they continue using their existing hardcoded SVG icons and display names.

### Changes

- **New:** Shared utility to extract display names and logos from env vars, with URL protocol validation to prevent XSS via javascript: or data: URI schemes
- **New:** 13 unit tests covering env var reading, URL validation (XSS prevention), missing configs, and provider ID resolution
- **Refactored:** Extract duplicated provider resolution helper from both login and register pages into a single shared function
- **Modified:** Auth content component accepts and forwards provider display names and logos as optional props
- **Modified:** OAuth button component accepts an optional icon URL prop; renders an image for custom logos, falling back to hardcoded SVG icons for standard providers

### Backward Compatibility

- **Zero impact on existing providers** — Standard providers (GitHub, Google, Azure, Apple) are never looked up, so their behavior is unchanged
- **Zero impact when env vars are missing** — Graceful fallback to raw provider ID and no icon. No crashes
- **New props are optional** — Default to undefined, preserving existing behavior

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Additional Notes

### Security

Logo URLs are validated using URL parsing — only http and https protocols are accepted. javascript:, data:, and malformed URLs are silently rejected. This prevents XSS if the env var is misconfigured.

### Test Coverage

All 682 existing tests continue to pass. 13 new tests added:

| Test Category | Count | Covers |
|---|---|---|
| Env var reading | 5 | OIDC name/logo, OAuth name/logo, both together |
| Missing configs | 2 | Missing name only, missing logo only |
| URL validation | 4 | javascript:, data:, http://, malformed URLs |
| Provider ID resolution | 2 | Array config, empty/missing fallback to credentials |

### Depends On

This PR is extension to the feat/sso-oauth-plugin branch from PR [#1056](https://github.com/f/prompts.chat/pull/1056)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auth providers can show custom display names and logos sourced from server configuration.
  * Login and registration pages now present provider buttons with configured icons and improved fallbacks (initials or default icons).

* **Tests**
  * Added tests verifying provider metadata extraction, display name/logo handling, and secure logo URL validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->