### PR TITLE
Fix dark mode favicon

### DIFF
--- a/public/favicon/favicon.svg
+++ b/public/favicon/favicon.svg
@@ -5,7 +5,7 @@
         </g>
     </g>
     <style>
-    @media (prefers-color-scheme: light) { :root { filter: none; } }
-    @media (prefers-color-scheme: dark) { :root { filter: invert(100%); } }
+    path { fill: #000000; }
+    @media (prefers-color-scheme: dark) { path { fill: #ffffff; } }
     </style>
 </svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -62,12 +62,12 @@ export const metadata: Metadata = {
   publisher: "prompts.chat",
   icons: {
     icon: [
-      { url: "/favicon/favicon.ico", sizes: "48x48" },
-      { url: "/favicon/favicon-96x96.png", sizes: "96x96", type: "image/png" },
       { url: "/favicon/favicon.svg", type: "image/svg+xml" },
+      { url: "/favicon/favicon-96x96.png", sizes: "96x96", type: "image/png" },
+      { url: "/favicon/favicon.ico", sizes: "48x48" },
     ],
     apple: "/favicon/apple-touch-icon.png",
-    shortcut: "/favicon/favicon.ico",
+    shortcut: "/favicon/favicon.svg",
   },
   manifest: "/favicon/site.webmanifest",
   other: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "packages"]
 }


### PR DESCRIPTION
## Summary
- prefer the adaptive SVG favicon so dark mode can use a white icon
- keep PNG/ICO raster assets as fallback icons
- exclude standalone package sources from the app TypeScript project so production builds do not type-check package-only CLI code

## Validation
- `npm run lint`
- `DATABASE_URL='postgresql://test:test@localhost:5432/test' npm test`
- `DATABASE_URL='postgresql://test:test@localhost:5432/test' npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated favicon and application icon configuration with SVG as the primary format, followed by PNG and ICO fallbacks.

* **Chores**
  * Updated TypeScript configuration to exclude additional directories from compilation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/f/prompts.chat/pull/1183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->