### PR TITLE
chore: make compose.yml support both pre-built images or building locally

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -2,32 +2,27 @@
 
 Run your own prompts.chat instance using Docker Compose.
 
+[`compose.yml`](/compose.yml) supports both the pre-built container image being fetched from ghcr.io, or being built locally.
+
 ## Quick Start
+
+### To build locally
 
 ```bash
 git clone https://github.com/f/prompts.chat.git
 cd prompts.chat
-docker compose up -d
+docker compose up -d --build
 ```
 
 Open http://localhost:4444 in your browser.
 
-## Using a Pre-built Image
+### Using a Pre-built Image
 
-Edit `compose.yml` and replace the `build` block with the published image:
-
-```yaml
-services:
-  app:
-    # build:
-    #   context: .
-    #   dockerfile: docker/Dockerfile
-    image: ghcr.io/f/prompts.chat:latest
-```
-
-Then run:
+Simply remove the `--build` flag from the command:
 
 ```bash
+git clone https://github.com/f/prompts.chat.git
+cd prompts.chat
 docker compose up -d
 ```
 
@@ -43,6 +38,17 @@ docker run -d \
   -e DATABASE_URL="postgresql://user:pass@your-db-host:5432/prompts?schema=public" \
   -e AUTH_SECRET="$(openssl rand -base64 32)" \
   prompts.chat
+```
+
+Or if you simply want to use the pre-built image:
+
+```bash
+docker run -d \
+  --name prompts \
+  -p 4444:3000 \
+  -e DATABASE_URL="postgresql://user:pass@your-db-host:5432/prompts?schema=public" \
+  -e AUTH_SECRET="$(openssl rand -base64 32)" \
+  ghcr.io/f/prompts.chat:latest
 ```
 
 ## Custom Branding

--- a/compose.yml
+++ b/compose.yml
@@ -18,8 +18,8 @@ services:
 
   app:
     image: ghcr.io/f/prompts.chat:latest
-    # To build locally instead of using the pre-built image, comment out
-    # the 'image' line above and uncomment the build block below:
+    # By default, uses the pre-built image above. To build locally instead,
+    # run: docker compose up -d --build
     build:
        context: .
        dockerfile: docker/Dockerfile

--- a/compose.yml
+++ b/compose.yml
@@ -20,9 +20,9 @@ services:
     image: ghcr.io/f/prompts.chat:latest
     # To build locally instead of using the pre-built image, comment out
     # the 'image' line above and uncomment the build block below:
-    # build:
-    #   context: .
-    #   dockerfile: docker/Dockerfile
+    build:
+       context: .
+       dockerfile: docker/Dockerfile
     restart: unless-stopped
     ports:
       - "${PORT:-4444}:3000"


### PR DESCRIPTION
This PR ensures docker compose supporting both inheriting the pre-built images, or building locally, if you want to run locally and develop features. So the user does not have to modify docker compose whenever they want to switch from pre-built image to building locally, or vice versa.

It defaults to use pre-built images, but if you use `--build` flag it builds the image.

Also, I updated the documentation mentioning this non-breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Docker Quick Start to better explain using pre-built images versus building locally; added an option to run the pre-built image directly for standalone deployments.

* **Chores**
  * Updated deployment configuration to make local image building easy to enable alongside the default pre-built-image workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/f/prompts.chat/pull/1184)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->