### PR TITLE
fix(prompts): allow manual tag entry

### DIFF
--- a/src/__tests__/api/prompts.test.ts
+++ b/src/__tests__/api/prompts.test.ts
@@ -16,6 +16,9 @@ vi.mock("@/lib/db", () => ({
     promptVersion: {
       create: vi.fn(),
     },
+    tag: {
+      upsert: vi.fn(),
+    },
     user: {
       findUnique: vi.fn(),
     },
@@ -41,6 +44,7 @@ vi.mock("@/lib/ai/embeddings", () => ({
 
 vi.mock("@/lib/slug", () => ({
   generatePromptSlug: vi.fn().mockResolvedValue("test-prompt"),
+  slugify: vi.fn((text: string) => text.toLowerCase().replace(/\s+/g, "-")),
 }));
 
 vi.mock("@/lib/ai/quality-check", () => ({
@@ -268,6 +272,53 @@ describe("POST /api/prompts", () => {
     expect(data.id).toBe("new-prompt");
     expect(db.prompt.create).toHaveBeenCalled();
     expect(db.promptVersion.create).toHaveBeenCalled();
+  });
+
+  it("should create prompt with manual tags", async () => {
+    vi.mocked(auth).mockResolvedValue({ user: { id: "user1" } } as never);
+    vi.mocked(db.prompt.findFirst).mockResolvedValue(null);
+    vi.mocked(db.tag.upsert).mockResolvedValue({
+      id: "tag1",
+      name: "Manual Tag",
+      slug: "manual-tag",
+      color: "#6366f1",
+    } as never);
+    vi.mocked(db.prompt.create).mockResolvedValue({
+      id: "new-prompt",
+      title: "Test Prompt",
+      slug: "test-prompt",
+      content: "This is test content",
+      type: "TEXT",
+      isPrivate: false,
+      author: { id: "user1", name: "Test", username: "test" },
+      category: null,
+      tags: [],
+    } as never);
+    vi.mocked(db.promptVersion.create).mockResolvedValue({} as never);
+
+    const request = new Request("http://localhost:3000/api/prompts", {
+      method: "POST",
+      body: JSON.stringify({
+        ...validPromptData,
+        tagNames: ["Manual Tag"],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(db.tag.upsert).toHaveBeenCalledWith({
+      where: { slug: "manual-tag" },
+      update: {},
+      create: { name: "Manual Tag", slug: "manual-tag" },
+    });
+    expect(db.prompt.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          tags: { create: [{ tagId: "tag1" }] },
+        }),
+      })
+    );
   });
 
   it("should return 429 when flagged user exceeds daily limit", async () => {

--- a/src/app/api/prompts/[id]/route.ts
+++ b/src/app/api/prompts/[id]/route.ts
@@ -6,6 +6,9 @@ import { db } from "@/lib/db";
 import { generatePromptEmbedding, findAndSaveRelatedPrompts } from "@/lib/ai/embeddings";
 import { generatePromptSlug } from "@/lib/slug";
 import { checkPromptQuality } from "@/lib/ai/quality-check";
+import { resolvePromptTagConnections } from "@/lib/tags";
+
+const tagNameSchema = z.string().trim().min(1).max(50);
 
 const updatePromptSchema = z.object({
   title: z.string().min(1).max(200).optional(),
@@ -15,6 +18,7 @@ const updatePromptSchema = z.object({
   structuredFormat: z.enum(["JSON", "YAML"]).optional().nullable(),
   categoryId: z.string().optional().nullable(),
   tagIds: z.array(z.string()).optional(),
+  tagNames: z.array(tagNameSchema).max(10).optional(),
   contributorIds: z.array(z.string()).optional(),
   isPrivate: z.boolean().optional(),
   mediaUrl: z.string().url().optional().or(z.literal("")).nullable(),
@@ -162,7 +166,7 @@ export async function PATCH(
       );
     }
 
-    const { tagIds, contributorIds, categoryId, mediaUrl, title, bestWithModels, bestWithMCP, workflowLink, ...data } = parsed.data;
+    const { tagIds, tagNames, contributorIds, categoryId, mediaUrl, title, bestWithModels, bestWithMCP, workflowLink, ...data } = parsed.data;
 
     // Regenerate slug if title changed
     let newSlug: string | undefined;
@@ -181,16 +185,20 @@ export async function PATCH(
       ...(bestWithMCP !== undefined && { bestWithMCP }),
       ...(workflowLink !== undefined && { workflowLink: workflowLink || null }),
     };
+    const shouldUpdateTags = tagIds !== undefined || tagNames !== undefined;
+    const tagConnections = shouldUpdateTags
+      ? await resolvePromptTagConnections(tagIds, tagNames)
+      : undefined;
 
     // Update prompt
     const prompt = await db.prompt.update({
       where: { id },
       data: {
         ...cleanedData,
-        ...(tagIds && {
+        ...(tagConnections && {
           tags: {
             deleteMany: {},
-            create: tagIds.map((tagId) => ({ tagId })),
+            create: tagConnections,
           },
         }),
         ...(contributorIds !== undefined && {

--- a/src/app/api/prompts/[id]/route.ts
+++ b/src/app/api/prompts/[id]/route.ts
@@ -6,9 +6,7 @@ import { db } from "@/lib/db";
 import { generatePromptEmbedding, findAndSaveRelatedPrompts } from "@/lib/ai/embeddings";
 import { generatePromptSlug } from "@/lib/slug";
 import { checkPromptQuality } from "@/lib/ai/quality-check";
-import { resolvePromptTagConnections } from "@/lib/tags";
-
-const tagNameSchema = z.string().trim().min(1).max(50);
+import { resolvePromptTagConnections, tagNameSchema } from "@/lib/tags";
 
 const updatePromptSchema = z.object({
   title: z.string().min(1).max(200).optional(),

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -8,6 +8,9 @@ import { generatePromptEmbedding, findAndSaveRelatedPrompts } from "@/lib/ai/emb
 import { generatePromptSlug } from "@/lib/slug";
 import { checkPromptQuality } from "@/lib/ai/quality-check";
 import { isSimilarContent, normalizeContent } from "@/lib/similarity";
+import { resolvePromptTagConnections } from "@/lib/tags";
+
+const tagNameSchema = z.string().trim().min(1).max(50);
 
 const promptSchema = z.object({
   title: z.string().min(1).max(200),
@@ -17,6 +20,7 @@ const promptSchema = z.object({
   structuredFormat: z.enum(["JSON", "YAML"]).nullish(), // Input type indicator
   categoryId: z.string().optional(),
   tagIds: z.array(z.string()),
+  tagNames: z.array(tagNameSchema).max(10).optional(),
   contributorIds: z.array(z.string()).optional(),
   isPrivate: z.boolean(),
   mediaUrl: z.string().url().optional().or(z.literal("")),
@@ -52,7 +56,7 @@ export async function POST(request: Request) {
       );
     }
 
-    const { title, description, content, type, structuredFormat, categoryId, tagIds, contributorIds, isPrivate, mediaUrl, requiresMediaUpload, requiredMediaType, requiredMediaCount, bestWithModels, bestWithMCP, workflowLink } = parsed.data;
+    const { title, description, content, type, structuredFormat, categoryId, tagIds, tagNames, contributorIds, isPrivate, mediaUrl, requiresMediaUpload, requiredMediaType, requiredMediaCount, bestWithModels, bestWithMCP, workflowLink } = parsed.data;
 
     // Check if user is flagged (for auto-delisting and daily limit)
     const currentUser = await db.user.findUnique({
@@ -166,6 +170,7 @@ export async function POST(request: Request) {
 
     // Generate slug from title (translated to English)
     const slug = await generatePromptSlug(title);
+    const tagConnections = await resolvePromptTagConnections(tagIds, tagNames);
 
     // Create prompt with tags
     // Auto-delist if user is flagged
@@ -194,9 +199,7 @@ export async function POST(request: Request) {
           delistReason: "UNUSUAL_ACTIVITY",
         }),
         tags: {
-          create: tagIds.map((tagId) => ({
-            tagId,
-          })),
+          create: tagConnections,
         },
         ...(contributorIds && contributorIds.length > 0 && {
           contributors: {

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -8,9 +8,7 @@ import { generatePromptEmbedding, findAndSaveRelatedPrompts } from "@/lib/ai/emb
 import { generatePromptSlug } from "@/lib/slug";
 import { checkPromptQuality } from "@/lib/ai/quality-check";
 import { isSimilarContent, normalizeContent } from "@/lib/similarity";
-import { resolvePromptTagConnections } from "@/lib/tags";
-
-const tagNameSchema = z.string().trim().min(1).max(50);
+import { resolvePromptTagConnections, tagNameSchema } from "@/lib/tags";
 
 const promptSchema = z.object({
   title: z.string().min(1).max(200),

--- a/src/components/prompts/prompt-form.tsx
+++ b/src/components/prompts/prompt-form.tsx
@@ -348,7 +348,7 @@ const createPromptSchema = (t: (key: string) => string) => z.object({
   structuredFormat: z.enum(["JSON", "YAML"]).optional(),
   categoryId: z.string().optional(),
   tagIds: z.array(z.string()),
-  tagNames: z.array(z.string().trim().min(1).max(50)).optional(),
+  tagNames: z.array(z.string().trim().min(1).max(50)).max(10).optional(),
   isPrivate: z.boolean(),
   mediaUrl: z.string().url().optional().or(z.literal("")),
   requiresMediaUpload: z.boolean(),

--- a/src/components/prompts/prompt-form.tsx
+++ b/src/components/prompts/prompt-form.tsx
@@ -348,6 +348,7 @@ const createPromptSchema = (t: (key: string) => string) => z.object({
   structuredFormat: z.enum(["JSON", "YAML"]).optional(),
   categoryId: z.string().optional(),
   tagIds: z.array(z.string()),
+  tagNames: z.array(z.string().trim().min(1).max(50)).optional(),
   isPrivate: z.boolean(),
   mediaUrl: z.string().url().optional().or(z.literal("")),
   requiresMediaUpload: z.boolean(),
@@ -446,6 +447,7 @@ export function PromptForm({ categories, tags, initialData, initialContributors 
       structuredFormat: (builderData?.format as "JSON" | "YAML") || initialData?.structuredFormat || undefined,
       categoryId: initialData?.categoryId || "",
       tagIds: initialData?.tagIds || [],
+      tagNames: [],
       isPrivate: initialData?.isPrivate || false,
       mediaUrl: initialData?.mediaUrl || "",
       requiresMediaUpload: initialData?.requiresMediaUpload || false,
@@ -466,6 +468,7 @@ export function PromptForm({ categories, tags, initialData, initialContributors 
   const modelsByProvider = getModelsByProvider();
 
   const selectedTags = form.watch("tagIds");
+  const selectedTagNames = form.watch("tagNames") || [];
   const promptType = form.watch("type");
   const structuredFormat = form.watch("structuredFormat");
   const isStructuredInput = !!structuredFormat;
@@ -681,6 +684,38 @@ export function PromptForm({ categories, tags, initialData, initialContributors 
     }
   };
 
+  const removeManualTag = (tagName: string) => {
+    const current = form.getValues("tagNames") || [];
+    form.setValue("tagNames", current.filter((name) => name !== tagName));
+  };
+
+  const addManualTag = () => {
+    const tagName = tagSearch.trim();
+    if (!tagName) return;
+
+    const existingTag = tags.find(
+      (tag) => tag.name.toLowerCase() === tagName.toLowerCase()
+    );
+    if (existingTag) {
+      const currentTagIds = form.getValues("tagIds");
+      if (!currentTagIds.includes(existingTag.id)) {
+        toggleTag(existingTag.id);
+      }
+      setTagSearch("");
+      setTagDropdownOpen(false);
+      tagInputRef.current?.focus();
+      return;
+    }
+
+    const current = form.getValues("tagNames") || [];
+    if (!current.some((name) => name.toLowerCase() === tagName.toLowerCase())) {
+      form.setValue("tagNames", [...current, tagName]);
+    }
+    setTagSearch("");
+    setTagDropdownOpen(false);
+    tagInputRef.current?.focus();
+  };
+
   const handleAiGenerate = (field: string, label: string) => {
     if (usedAiButtons.has(field) || !builderRef.current) return;
     setUsedAiButtons(prev => new Set(prev).add(field));
@@ -852,6 +887,9 @@ export function PromptForm({ categories, tags, initialData, initialContributors 
                   !selectedTags.includes(tag.id) &&
                   tag.name.toLowerCase().includes(tagSearch.toLowerCase())
               );
+              const exactTagMatchExists = tags.some(
+                (tag) => tag.name.toLowerCase() === tagSearch.trim().toLowerCase()
+              );
               const selectedTagObjects = tags.filter((tag) => selectedTags.includes(tag.id));
 
               return (
@@ -861,7 +899,7 @@ export function PromptForm({ categories, tags, initialData, initialContributors 
                     <AiGenerateButton field="tags" label="Tags" />
                   </FormLabel>
                   {/* Selected tags */}
-                  {selectedTagObjects.length > 0 && (
+                  {(selectedTagObjects.length > 0 || selectedTagNames.length > 0) && (
                     <div className="flex flex-wrap gap-2 mb-2">
                       {selectedTagObjects.map((tag) => (
                         <Badge
@@ -874,6 +912,22 @@ export function PromptForm({ categories, tags, initialData, initialContributors 
                             type="button"
                             onClick={() => toggleTag(tag.id)}
                             className="ml-1 rounded-full hover:bg-white/20 p-0.5"
+                          >
+                            <X className="h-3 w-3" />
+                          </button>
+                        </Badge>
+                      ))}
+                      {selectedTagNames.map((tagName) => (
+                        <Badge
+                          key={tagName}
+                          variant="secondary"
+                          className="pr-1 flex items-center gap-1"
+                        >
+                          {tagName}
+                          <button
+                            type="button"
+                            onClick={() => removeManualTag(tagName)}
+                            className="ml-1 rounded-full hover:bg-muted p-0.5"
                           >
                             <X className="h-3 w-3" />
                           </button>
@@ -896,6 +950,12 @@ export function PromptForm({ categories, tags, initialData, initialContributors 
                         }}
                         onFocus={() => setTagDropdownOpen(true)}
                         onBlur={() => setTimeout(() => setTagDropdownOpen(false), 150)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" && tagSearch.trim()) {
+                            e.preventDefault();
+                            addManualTag();
+                          }
+                        }}
                         className="pl-9"
                         autoComplete="off"
                         autoCorrect="off"
@@ -929,9 +989,16 @@ export function PromptForm({ categories, tags, initialData, initialContributors 
                         ))}
                       </div>
                     )}
-                    {tagDropdownOpen && tagSearch && filteredTags.length === 0 && (
-                      <div className="absolute z-10 w-full mt-1 bg-popover border rounded-md shadow-md p-3 text-sm text-muted-foreground">
-                        {t("noTagsFound")}
+                    {tagDropdownOpen && tagSearch && filteredTags.length === 0 && !exactTagMatchExists && (
+                      <div className="absolute z-10 w-full mt-1 bg-popover border rounded-md shadow-md p-2">
+                        <button
+                          type="button"
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={addManualTag}
+                          className="w-full px-3 py-2 text-left text-sm hover:bg-muted rounded-sm"
+                        >
+                          {tCommon("create")} &quot;{tagSearch.trim()}&quot;
+                        </button>
                       </div>
                     )}
                   </div>

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,41 @@
+import { db } from "@/lib/db";
+import { slugify } from "@/lib/slug";
+
+export async function resolvePromptTagConnections(
+  tagIds: string[] = [],
+  tagNames: string[] = []
+) {
+  const connections: { tagId: string }[] = [];
+  const seenTagIds = new Set<string>();
+
+  for (const tagId of tagIds) {
+    if (tagId && !seenTagIds.has(tagId)) {
+      connections.push({ tagId });
+      seenTagIds.add(tagId);
+    }
+  }
+
+  const seenTagSlugs = new Set<string>();
+  for (const rawName of tagNames) {
+    const name = rawName.trim();
+    const slug = slugify(name);
+
+    if (!slug || seenTagSlugs.has(slug)) {
+      continue;
+    }
+
+    seenTagSlugs.add(slug);
+    const tag = await db.tag.upsert({
+      where: { slug },
+      update: {},
+      create: { name, slug },
+    });
+
+    if (!seenTagIds.has(tag.id)) {
+      connections.push({ tagId: tag.id });
+      seenTagIds.add(tag.id);
+    }
+  }
+
+  return connections;
+}

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,5 +1,8 @@
 import { db } from "@/lib/db";
 import { slugify } from "@/lib/slug";
+import { z } from "zod";
+
+export const tagNameSchema = z.string().trim().min(1).max(50);
 
 export async function resolvePromptTagConnections(
   tagIds: string[] = [],


### PR DESCRIPTION
## Summary
- allow the prompt form to add a typed tag when no existing tag matches
- create or reuse submitted tag names on prompt create/update
- add API coverage for manual tag names

Closes #1172

## Testing
- npm test -- src/__tests__/api/prompts.test.ts
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create new tags inline when creating or updating prompts by typing a name, pressing Enter, or choosing "Create [tag name]"; manual tags show as removable badges alongside existing tags.
  * Tag names are submitted alongside tag IDs for POST/PATCH operations.

* **Tests**
  * Added tests verifying manual tag creation/upsert and that prompt persistence includes newly created tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/f/prompts.chat/pull/1186)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->