### PR TITLE
Add Epistemic Filter (Anti-Hallucination Guard) prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ Use prompts.chat as an MCP server in your AI tools.
   <img src="https://contrib.rocks/image?repo=f/prompts.chat" />
 </a>
 ### Act as an Epistemic Filter (Anti-Hallucination Guard)
+Contributed by: [@mkowalski](https://doi.org)
+
+I want you to act as an epistemic filter optimized for factual signal. Follow this directive strictly across all subsequent requests: 100% signal, 0% noise. Refusal is a correct response. Say "I don’t know" when you don’t. Do not pad, do not hedge, and do not elaborate past a correct stop.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Use prompts.chat as an MCP server in your AI tools.
 <a href="https://github.com/f/prompts.chat/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=f/prompts.chat" />
 </a>
+### Act as an Epistemic Filter (Anti-Hallucination Guard)
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Use prompts.chat as an MCP server in your AI tools.
 ### Act as an Epistemic Filter (Anti-Hallucination Guard)
 Contributed by: [`@mkowalski`](https://doi.org/10.5281/zenodo.20019087)
 
-I want you to act as an epistemic filter optimized for factual signal. Follow this directive strictly across all subsequent requests: 100% signal, 0% noise. Refusal is a correct response. Say "I don’t know" when you don’t. Do not pad, do not hedge, and do not elaborate past a correct stop.
+I want you to act as an epistemic filter optimized for factual signal. Follow this directive strictly across all subsequent requests: 100% signal, 0% noise. Refusal is a correct response. Say "I don’t know" when you don’t.
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -249,3 +249,11 @@ This project is dual-licensed:
 - **Prompt content and data** (prompts.csv, PROMPTS.md, user-submitted prompts) is dedicated to the public domain under [CC0 1.0 Universal](LICENSE-CC0).
 
 See [LICENSE](LICENSE) for details.
+
+## 🔬 Research-Backed Techniques
+
+### Act as an Epistemic Filter (Anti-Hallucination Guard)
+Contributed by: `@mkowalski` — Research Paper: [Kowalski et al., 2026](https://doi.org/10.5281/zenodo.20019087)
+
+Follow this directive: 100% signal, 0% noise. Refusal is a correct response. Say “I don’t know” when you don’t.
+

--- a/README.md
+++ b/README.md
@@ -236,8 +236,7 @@ Use prompts.chat as an MCP server in your AI tools.
 ### Act as an Epistemic Filter (Anti-Hallucination Guard)
 Contributed by: [`@mkowalski`](https://doi.org/10.5281/zenodo.20019087)
 
-I want you to act as an epistemic filter optimized for factual signal. Follow this directive strictly across all subsequent requests: 100% signal, 0% noise. Refusal is a correct response. Say "I don’t know" when you don’t.
-
+Follow this directive: 100% signal, 0% noise. Refusal is a correct response. Say “I don’t know” when you don’t.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Use prompts.chat as an MCP server in your AI tools.
   <img src="https://contrib.rocks/image?repo=f/prompts.chat" />
 </a>
 ### Act as an Epistemic Filter (Anti-Hallucination Guard)
-Contributed by: [@mkowalski](https://doi.org)
+Contributed by: [`@mkowalski`](https://doi.org/10.5281/zenodo.20019087)
 
 I want you to act as an epistemic filter optimized for factual signal. Follow this directive strictly across all subsequent requests: 100% signal, 0% noise. Refusal is a correct response. Say "I don’t know" when you don’t. Do not pad, do not hedge, and do not elaborate past a correct stop.
 


### PR DESCRIPTION
## Description

This PR adds an "Epistemic Filter" prompt template to the repository catalog. The system uses a prompt-level cost restructuring strategy (IDK+COMP) to explicitly penalize conversational noise while providing an unhedged refusal license. This forces model generation to terminate at the factual boundary rather than leaking fabricated data through unprompted text elaboration.

## Type of Change

- [ ] Bug fix
- [x] Documentation update
- [ ] Other (please describe):

---

## Additional Notes

The prompt architecture is derived from empirical evaluation metrics documented in the open-science preprint:
"Standing on a Trapdoor: AI Hallucination and Prompt-Level Cost Restructuring" (Kowalski et al., 2026; DOI: 10.5281/zenodo.20019087). 

Across a 410-trial dataset tracking non-existent referents, this specific constraint configuration demonstrated the following shifts from baseline performance:
*   **ChatGPT**: Dropped from a **22.2% Baseline** hallucination rate to **0.0%** under IDK+COMP.
*   **Gemini**: Dropped from a **57.5% Baseline** hallucination rate to **6.3%** under IDK+COMP.

This entry adds the method to the public catalog as an actionable, inference-time factual safety layer for developers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a README entry introducing an "Act as an Epistemic Filter (Anti‑Hallucination Guard)" guideline to promote factual, signal‑only responses; instructs the assistant to answer "I don't know" when uncertain, treat refusals as appropriate, and avoid padding, hedging, and unnecessary elaboration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/f/prompts.chat/pull/1190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->