### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,3 +266,35 @@ Currently no automated tests. When implementing:
 1. Update `prisma/schema.prisma`
 2. Run `npm run db:migrate` to create migration
 3. Update related TypeScript types if needed
+
+## Cursor Cloud specific instructions
+
+### Services
+
+| Service | How to start | Notes |
+|---------|-------------|-------|
+| PostgreSQL | `sudo pg_ctlcluster 16 main start` | Must be started before the app. Database `prompts_chat` is pre-created. |
+| Next.js dev server | `npm run dev` | Runs on port 3000 with Turbopack. |
+
+### Environment
+
+- **Node.js 24.x** is required (`engines` in `package.json`). Use `nvm use 24` if not already active.
+- `.env` must contain `DATABASE_URL`, `DIRECT_URL`, `AUTH_SECRET` (or `NEXTAUTH_SECRET`), and `AUTH_TRUST_HOST=true`. See `.env.example` for the full template.
+- `DIRECT_URL` must be set even for local development — Prisma schema references it for `directUrl`. Set it to the same value as `DATABASE_URL` for local PostgreSQL.
+
+### Database
+
+- Run `npx prisma migrate deploy` (not `db:migrate`) to apply existing migrations non-interactively.
+- `npm run db:seed` fetches live data from prompts.chat and creates an admin user (`admin@prompts.chat` / `password123`).
+- After schema changes, use `npm run db:migrate` which runs `prisma migrate dev` interactively.
+
+### Authentication
+
+- The default config (`prompts.config.ts`) uses GitHub, Google, and Apple OAuth providers — **not** credentials auth. To test registration/login without OAuth secrets, temporarily add `"credentials"` to the `auth.providers` array and set `allowRegistration: true`.
+- Admin login: `admin@prompts.chat` / `password123` (created by seed, requires credentials provider).
+
+### Testing
+
+- `npm test` runs Vitest (709+ tests). All tests use mocks and don't require a running database.
+- `npm run lint` runs ESLint. The codebase has ~200 pre-existing warnings (no errors).
+- No pre-commit hooks or CI-gating lint-staged configuration exists.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a `## Cursor Cloud specific instructions` section to AGENTS.md with durable development environment guidance for future cloud agents.

## Type of Change

- [x] Documentation update

## What's included

- PostgreSQL and Next.js dev server startup guidance
- Node.js 24.x requirement and nvm usage notes
- Environment variable documentation (`DIRECT_URL` gotcha for Prisma)
- Database migration and seed instructions
- Authentication provider configuration notes (credentials vs OAuth)
- Testing commands with pre-existing warning context

## Demo

The development environment was fully set up and verified:

[demo-register-and-create-prompt.mp4](https://cursor.com/agents/bc-6355672c-0702-4c10-8254-191387501b76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo-register-and-create-prompt.mp4)

Full end-to-end demo: homepage load, user registration, login, and prompt creation.

[Homepage loaded](https://cursor.com/agents/bc-6355672c-0702-4c10-8254-191387501b76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaded.webp)
[Prompt created successfully](https://cursor.com/agents/bc-6355672c-0702-4c10-8254-191387501b76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprompt_created.webp)

## Additional Notes

The update script installs Node.js 24.x via nvm, runs `npm install`, and generates the Prisma client. PostgreSQL must be started separately as a service before running the app.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6355672c-0702-4c10-8254-191387501b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6355672c-0702-4c10-8254-191387501b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

