### PR TITLE
Fix VS Code Copilot Chat deep links

### DIFF
--- a/packages/prompts.chat/src/__tests__/platforms.test.ts
+++ b/packages/prompts.chat/src/__tests__/platforms.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { buildUrl, codePlatforms } from '../cli/platforms';
+
+describe('platform URL builder', () => {
+  it('builds VS Code Copilot Chat deep links with encoded prompts', () => {
+    const vscode = codePlatforms.find((platform) => platform.id === 'vscode');
+    const insiders = codePlatforms.find((platform) => platform.id === 'vscode-insiders');
+
+    expect(vscode).toBeDefined();
+    expect(insiders).toBeDefined();
+    expect(vscode?.baseUrl).toBe('vscode://GitHub.Copilot-Chat/chat');
+    expect(insiders?.baseUrl).toBe('vscode-insiders://GitHub.Copilot-Chat/chat');
+
+    expect(buildUrl('vscode', vscode!.baseUrl, 'Review this code & explain it')).toBe(
+      'vscode://GitHub.Copilot-Chat/chat?prompt=Review%20this%20code%20%26%20explain%20it',
+    );
+    expect(buildUrl('vscode-insiders', insiders!.baseUrl, '/fix failing tests')).toBe(
+      'vscode-insiders://GitHub.Copilot-Chat/chat?prompt=%2Ffix%20failing%20tests',
+    );
+  });
+});

--- a/packages/prompts.chat/src/cli/platforms.ts
+++ b/packages/prompts.chat/src/cli/platforms.ts
@@ -25,8 +25,8 @@ export const videoPlatforms: Platform[] = [
 
 export const codePlatforms: Platform[] = [
   { id: "windsurf", name: "Windsurf", baseUrl: "windsurf://", isDeeplink: true, supportsQuerystring: false, sponsor: true },
-  { id: "vscode", name: "VS Code", baseUrl: "vscode://", isDeeplink: true, supportsQuerystring: false },
-  { id: "vscode-insiders", name: "VS Code Insiders", baseUrl: "vscode-insiders://", isDeeplink: true, supportsQuerystring: false },
+  { id: "vscode", name: "VS Code", baseUrl: "vscode://GitHub.Copilot-Chat/chat", isDeeplink: true },
+  { id: "vscode-insiders", name: "VS Code Insiders", baseUrl: "vscode-insiders://GitHub.Copilot-Chat/chat", isDeeplink: true },
   { id: "cursor", name: "Cursor", baseUrl: "cursor://anysphere.cursor-deeplink/prompt", isDeeplink: true },
   { id: "goose", name: "Goose", baseUrl: "goose://recipe", isDeeplink: true },
   { id: "github-copilot", name: "GitHub Copilot Chat", baseUrl: "https://github.com/copilot" },
@@ -71,6 +71,9 @@ export function buildUrl(
   switch (platformId) {
     case "cursor":
       return `${baseUrl}?text=${encoded}`;
+    case "vscode":
+    case "vscode-insiders":
+      return `${baseUrl}?prompt=${encoded}`;
     case "goose": {
       const config = JSON.stringify({
         version: "1.0.0",

--- a/packages/raycast-extension/src/utils.ts
+++ b/packages/raycast-extension/src/utils.ts
@@ -175,15 +175,15 @@ export const codePlatforms: Platform[] = [
   {
     id: "vscode",
     name: "VS Code",
-    baseUrl: "vscode://",
-    supportsQuerystring: false,
+    baseUrl: "vscode://GitHub.Copilot-Chat/chat",
+    supportsQuerystring: true,
     isDeeplink: true,
   },
   {
     id: "vscode-insiders",
     name: "VS Code Insiders",
-    baseUrl: "vscode-insiders://",
-    supportsQuerystring: false,
+    baseUrl: "vscode-insiders://GitHub.Copilot-Chat/chat",
+    supportsQuerystring: true,
     isDeeplink: true,
   },
   {
@@ -243,6 +243,9 @@ export function buildUrl(
     // IDE deeplinks
     case "cursor":
       return `${baseUrl}?text=${encoded}`;
+    case "vscode":
+    case "vscode-insiders":
+      return `${baseUrl}?prompt=${encoded}`;
     case "goose":
     case "goose-chat": {
       const config = JSON.stringify({

--- a/src/components/prompts/run-prompt-button.tsx
+++ b/src/components/prompts/run-prompt-button.tsx
@@ -79,8 +79,8 @@ const videoPlatforms: Platform[] = [
 const codePlatforms: Platform[] = [
   { id: "commandcode", name: "Command Code", baseUrl: "https://commandcode.ai/?utm_source=prompts.chat", supportsQuerystring: false, sponsor: true },
   { id: "windsurf", name: "Windsurf", baseUrl: "windsurf://", isDeeplink: true, supportsQuerystring: false, sponsor: true },
-  { id: "vscode", name: "VS Code", baseUrl: "vscode://", isDeeplink: true, supportsQuerystring: false },
-  { id: "vscode-insiders", name: "VS Code Insiders", baseUrl: "vscode-insiders://", isDeeplink: true, supportsQuerystring: false },
+  { id: "vscode", name: "VS Code", baseUrl: "vscode://GitHub.Copilot-Chat/chat", isDeeplink: true },
+  { id: "vscode-insiders", name: "VS Code Insiders", baseUrl: "vscode-insiders://GitHub.Copilot-Chat/chat", isDeeplink: true },
   { id: "cursor", name: "Cursor", baseUrl: "cursor://anysphere.cursor-deeplink/prompt", isDeeplink: true },
   { id: "goose", name: "Goose", baseUrl: "goose://recipe", isDeeplink: true },
     {
@@ -136,6 +136,9 @@ function buildUrl(platformId: string, baseUrl: string, promptText: string, promp
     // IDE deeplinks
     case "cursor":
       return `${baseUrl}?text=${encoded}`;
+    case "vscode":
+    case "vscode-insiders":
+      return `${baseUrl}?prompt=${encoded}`;
     case "goose": {
       const config = JSON.stringify({
         version: "1.0.0",


### PR DESCRIPTION
## Description

The Run button listed VS Code and VS Code Insiders, but those entries only opened the editor and required users to paste the prompt manually. This updates both entries to use the GitHub Copilot Chat URI handler so prompts open prefilled in VS Code or VS Code Insiders.

The same deep-link behavior is wired through the web Run button, the packaged CLI platform builder, and the Raycast extension utility. A small regression test covers the generated VS Code URLs and prompt encoding.

## Type of Change

- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

---

## ⚠️ Want to Add a New Prompt?

**Please don't edit `prompts.csv` directly!**

Instead, visit **[prompts.chat](https://prompts.chat)** and:

1. **Login with GitHub** - Click the login button and authenticate with your GitHub account
2. **Create your prompt** - Use the prompt editor to add your new prompt
3. **Submit** - Your prompt will be reviewed and a [GitHub Action](https://github.com/f/prompts.chat/actions/workflows/update-contributors.yml) will automatically create a commit on your behalf

This ensures proper attribution, formatting, and keeps the repository in sync. You'll also appear on the [Contributors page](https://github.com/f/prompts.chat/graphs/contributors)!

---

## Additional Notes

Validation run:

- `npm run lint -- --quiet`
- `npm --prefix packages/prompts.chat run typecheck`
- `cd packages/prompts.chat && npx vitest run --config /dev/null src/__tests__/platforms.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Fix VS Code Copilot Chat Deep Links

## Overview
This PR fixes VS Code and VS Code Insiders deep links to use the GitHub Copilot Chat URI handler, enabling prompts to open prefilled directly in the editors rather than requiring manual pasting. The fix is applied consistently across the web UI, CLI, and Raycast extension.

## Changes Made

### Platform Configuration Updates
- **VS Code base URL**: Updated from `vscode://` to `vscode://GitHub.Copilot-Chat/chat` with `isDeeplink: true`
- **VS Code Insiders base URL**: Updated from `vscode-insiders://` to `vscode-insiders://GitHub.Copilot-Chat/chat` with `isDeeplink: true`
- Both platforms now support query string parameters for passing prompts

### URL Generation
Extended the `buildUrl()` function in all affected modules to handle VS Code platforms by generating URLs in the format `${baseUrl}?prompt=${encoded}`, properly encoding special characters in prompt text.

### Affected Components
1. **Web Run Button** (`src/components/prompts/run-prompt-button.tsx`)
2. **CLI Platform Builder** (`packages/prompts.chat/src/cli/platforms.ts`)
3. **Raycast Extension** (`packages/raycast-extension/src/utils.ts`)

### Test Coverage
- **New regression test** (`packages/prompts.chat/src/__tests__/platforms.test.ts`): Verifies VS Code and VS Code Insiders platform configurations, validates baseUrl values, and tests that `buildUrl()` correctly generates URL-encoded prompt query strings with proper handling of special characters (e.g., ampersands, forward slashes)

## Validation
All validation checks passed:
- Linting checks
- TypeScript type checking
- Vitest regression test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->