### PR TITLE
Fix MCP transport Response realm corruption

### DIFF
--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import { Readable } from "node:stream";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import {
   ElicitResultSchema,
   ListPromptsRequestSchema,
@@ -1384,6 +1385,75 @@ async function parseBody(req: NextApiRequest): Promise<unknown> {
   });
 }
 
+function toWebHeaders(headers: NextApiRequest["headers"]): Headers {
+  const webHeaders = new Headers();
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        webHeaders.append(key, item);
+      }
+    } else {
+      webHeaders.set(key, String(value));
+    }
+  }
+
+  return webHeaders;
+}
+
+async function sendWebResponse(response: Response, res: NextApiResponse): Promise<void> {
+  res.status(response.status);
+
+  response.headers.forEach((value, key) => {
+    res.setHeader(key, value);
+  });
+
+  if (!response.body) {
+    res.end();
+    return;
+  }
+
+  const nodeStream = Readable.fromWeb(response.body as import("node:stream/web").ReadableStream);
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+
+    const cleanup = () => {
+      nodeStream.off("error", onError);
+      res.off("error", onError);
+      res.off("finish", onFinish);
+      res.off("close", onClose);
+    };
+
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      callback();
+    };
+
+    const onError = (error: Error) => {
+      settle(() => reject(error));
+    };
+
+    const onFinish = () => {
+      settle(resolve);
+    };
+
+    const onClose = () => {
+      nodeStream.destroy();
+      settle(resolve);
+    };
+
+    nodeStream.once("error", onError);
+    res.once("error", onError);
+    res.once("finish", onFinish);
+    res.once("close", onClose);
+    nodeStream.pipe(res);
+  });
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (!appConfig.features.mcp) {
     return res.status(404).json({ error: "MCP is not enabled" });
@@ -1442,9 +1512,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const server = createServer(serverOptions);
+  let transport: WebStandardStreamableHTTPServerTransport | null = null;
 
   try {
-    const transport = new StreamableHTTPServerTransport({
+    transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     });
 
@@ -1501,12 +1572,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
     }
 
-    await transport.handleRequest(req, res, body);
-
-    res.on("close", () => {
-      transport.close();
-      server.close();
+    const webRequest = new Request(url, {
+      method: req.method,
+      headers: toWebHeaders(req.headers),
     });
+
+    const response = await transport.handleRequest(webRequest, { parsedBody: body });
+    await sendWebResponse(response, res);
   } catch (error) {
     console.error("MCP error:", error);
     if (!res.headersSent) {
@@ -1524,5 +1596,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         });
       }
     }
+  } finally {
+    await transport?.close();
+    await server.close();
   }
 }


### PR DESCRIPTION
## Summary

- avoid the MCP SDK Node transport wrapper in the Next.js Pages API route
- use `WebStandardStreamableHTTPServerTransport` directly and bridge its Web `Response` back to `NextApiResponse`
- keep `globalThis.Request` / `globalThis.Response` untouched so Next.js proxy/middleware `instanceof Response` checks keep working

Closes #1205

## Root Cause

`StreamableHTTPServerTransport` currently goes through `@hono/node-server`. Hono's default `getRequestListener()` behavior overrides global Web APIs (`global.Request` and `global.Response`) with Hono wrapper classes.

After `/api/mcp` handles a request, Next.js proxy/middleware can later return a `NextResponse` created against the original/native `Response` realm. Next.js 16 then checks the proxy result with `instanceof Response`; because `global.Response` has been replaced, that check fails and the app starts returning:

```text
TypeError: Expected an instance of Response to be returned
```

This is especially visible in self-hosted Docker deployments where the same process continues serving all routes after MCP requests.

## Fix

The MCP endpoint now:

- builds a Web `Request` from the incoming `NextApiRequest` metadata
- passes the already parsed JSON-RPC body to `WebStandardStreamableHTTPServerTransport`
- streams the returned Web `Response` body to `NextApiResponse` with `Readable.fromWeb`
- closes the per-request transport/server in `finally`

This avoids `@hono/node-server` in the Next.js runtime path.

## Validation

Validated on a self-hosted Docker image based on Next.js 16.1.0 / `@modelcontextprotocol/sdk` 1.25.1:

- Docker image build completed successfully
- single `initialize`: 200
- 100 `initialize` requests: 100/100 200
- 100 `tools/call search_prompts` requests: 100/100 200
- `/`: 200 after stress tests
- `/api/health`: 200 after stress tests
- logs containing `Expected an instance of Response`: 0
- logs containing `MCP error`: 0

Note: stress tests varied `X-Forwarded-For` to avoid the existing 20 req/min/IP MCP rate limit while testing transport stability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Fixes a critical issue where the MCP endpoint corrupts the global `Response` realm in Next.js 16, causing subsequent application requests to fail with errors like “TypeError: Expected an instance of Response to be returned”.

## Root Cause

The MCP SDK’s `StreamableHTTPServerTransport` relies on Hono’s `getRequestListener()`, which replaces `globalThis.Request`/`globalThis.Response` with Hono wrapper classes. After `/api/mcp` runs, Next.js proxy/middleware attempts to return a `NextResponse` based on the original/native `Response` realm; in Next.js 16, the resulting `instanceof Response` check fails because the global `Response` constructor has been replaced.

## Solution

Switches the MCP HTTP handling to the Web-standard `WebStandardStreamableHTTPServerTransport`, bypassing Hono’s request/response integration entirely to keep global Web APIs untouched.

### Changes to `src/pages/api/mcp.ts`

- Uses `WebStandardStreamableHTTPServerTransport` instead of `StreamableHTTPServerTransport`.
- Adds Web interop helpers:
  - `toWebHeaders()` to convert `NextApiRequest.headers` into Web `Headers`.
  - `sendWebResponse()` to copy status/headers to `NextApiResponse` and pipe the Web `Response.body` via `Readable.fromWeb`, with coordinated error/finish handling and proper stream closing.
- Refactors the handler to:
  - Build a Web `Request` from the incoming URL/method and converted headers.
  - Pass the already-parsed JSON-RPC body directly to `transport.handleRequest(webRequest, { parsedBody: body })`.
  - Send the returned Web `Response` back to the client using `sendWebResponse()`.

### Lifecycle management

- Declares the per-request `transport` outside the `try` block.
- Ensures both the transport and the MCP server are always closed in a `finally` block.

## Impact

- Eliminates global `Request`/`Response` realm corruption.
- Maintains Next.js 16 compatibility with `instanceof Response` checks.
- Keeps MCP protocol support working without requiring upstream changes to the MCP SDK or Hono.

**Lines changed**: +82/-7
<!-- end of auto-generated comment: release notes by coderabbit.ai -->