### PR TITLE
Add OpenRuna prompt directory link

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ The setup wizard configures branding, theme, authentication (GitHub/Google/Azure
 
 ---
 
+## 📂 Related prompt directories
+
+- [OpenRuna](https://www.openruna.com/best/prompt-engineering-examples) — Graph directory of prompts, tools, and benchmarks with semantic search and MCP API.
+
 ## 🔌 Integrations
 
 ### CLI


### PR DESCRIPTION
Adds [OpenRuna prompt engineering examples](https://www.openruna.com/best/prompt-engineering-examples) — graph-linked prompt catalog (prompt → model → benchmark) with CC0 corpus and agent MCP at https://www.openruna.com/connectors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Added a new "📂 Related prompt directories" section to the README with a link to OpenRuna, which provides a graph-based directory of prompts, tools, and benchmarks with semantic search capabilities and MCP API access.

## Changes

**README.md**: Added a new "Related prompt directories" section referencing OpenRuna at https://www.openruna.com/best/prompt-engineering-examples, described as a graph directory of prompts, tools, and benchmarks with semantic search and MCP API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->