### PR TITLE
fix(types): add missing SVG module declarations to resolve compiler errors

### DIFF
--- a/src/types/svg.d.ts
+++ b/src/types/svg.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const content: any;
+  export default content;
+}


### PR DESCRIPTION
## Description

When running the strict TypeScript compiler (`npx tsc --noEmit`), the build pipeline throws `TS2307: Cannot find module` and `TS2322` type assignability errors whenever `.svg` files are imported (e.g., `src/components/layout/footer.tsx`, `src/app/docs/self-hosting/page.tsx`). Next.js requires explicit module declarations for static assets like SVGs to prevent compiler crashes during strict validation.

**The Fix**
- Added a global `src/types/svg.d.ts` module declaration file.
- Defined `*.svg` to export as `any`, satisfying the Next.js `<Image src={...} />` component requirements.
- The `tsconfig.json` correctly picks up the new declarations via the existing `**/*.ts` include directive.

## Type of Change

- [x] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

---
## ⚠️ Want to Add a New Prompt?
**Please don't edit `prompts.csv` directly!**

Instead, visit **[prompts.chat](https://prompts.chat)** and use the prompt editor to add your new prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a global TypeScript module declaration for `*.svg` files so SVG imports are recognized during strict type checking.

This resolves the compiler errors caused by importing SVGs in components/pages that use them with Next.js image handling, without requiring changes to existing `tsconfig.json` includes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->