### PR TITLE
docs: document Docker build memory requirement

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -8,6 +8,8 @@ Run your own prompts.chat instance using Docker Compose.
 
 ### To build locally
 
+Local builds run the full Next.js production build inside Docker. Allocate at least 4 GB of memory to Docker Desktop or your Docker daemon before running the build. If the build exits with code 137, Docker likely ran out of memory; increase the memory limit or use the pre-built image below.
+
 ```bash
 git clone https://github.com/f/prompts.chat.git
 cd prompts.chat


### PR DESCRIPTION
Summary:
- Documents the memory needed for local Docker production builds.
- Notes that exit code 137 usually indicates an OOM kill.
- Points users to the pre-built image when local Docker memory is constrained.

Testing:
- git diff --check

Fixes #1083

AI assistance: This documentation fix was prepared with AI assistance and reviewed before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Docker quick-start docs to warn that local production builds require enough Docker memory.

- Added guidance that an exit code `137` during the build usually means the process was killed for running out of memory.
- Pointed users to increase Docker memory or use the pre-built image when local resources are constrained.
- Documentation-only change; validated with `git diff --check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->