### PR TITLE
fix(mcp): return owner's own private prompts from get_prompt + accept category name/slug

### DIFF
--- a/src/__tests__/api/mcp-handler.test.ts
+++ b/src/__tests__/api/mcp-handler.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/db", () => ({
     user: { findUnique: vi.fn() },
     prompt: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
     tag: { findUnique: vi.fn(), create: vi.fn() },
+    category: { findMany: vi.fn(), findUnique: vi.fn() },
     $queryRaw: vi.fn(),
   },
 }));
@@ -80,6 +81,51 @@ function createMockRes(): NextApiResponse & {
   };
   return res as unknown as NextApiResponse & typeof res;
 }
+
+describe("findCategoryMatch - category resolution", () => {
+  const cats = [
+    { id: "1", name: "Writing & Content", slug: "writing" },
+    { id: "2", name: "Code Review", slug: "code-review" },
+    { id: "3", name: "Development", slug: "development" },
+  ];
+  let findCategoryMatch: (
+    categories: typeof cats,
+    input: string,
+  ) => (typeof cats)[number] | null;
+
+  beforeEach(async () => {
+    const mod = await import("@/pages/api/mcp");
+    findCategoryMatch = mod.findCategoryMatch;
+  });
+
+  it("matches an exact slug", () => {
+    expect(findCategoryMatch(cats, "code-review")?.id).toBe("2");
+  });
+
+  it("matches a slug case-insensitively", () => {
+    expect(findCategoryMatch(cats, "Code-Review")?.id).toBe("2");
+  });
+
+  it("matches by category name", () => {
+    expect(findCategoryMatch(cats, "Development")?.id).toBe("3");
+  });
+
+  it("matches a name with different spacing/case via slugify", () => {
+    expect(findCategoryMatch(cats, "code_review")?.id).toBe("2");
+  });
+
+  it("matches a name whose slug differs from slugify (Writing & Content -> writing)", () => {
+    expect(findCategoryMatch(cats, "Writing & Content")?.id).toBe("1");
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(findCategoryMatch(cats, "nonexistent-category")).toBeNull();
+  });
+
+  it("returns null for whitespace-only input", () => {
+    expect(findCategoryMatch(cats, "   ")).toBeNull();
+  });
+});
 
 describe("MCP API handler - HTTP method routing", () => {
   let handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void>;

--- a/src/__tests__/api/mcp-handler.test.ts
+++ b/src/__tests__/api/mcp-handler.test.ts
@@ -127,6 +127,38 @@ describe("findCategoryMatch - category resolution", () => {
   });
 });
 
+describe("buildPromptVisibilityFilter - get_prompt/get_skill visibility", () => {
+  let buildPromptVisibilityFilter: (
+    user: { id: string } | null | undefined,
+  ) => Record<string, unknown>;
+
+  beforeEach(async () => {
+    const mod = await import("@/pages/api/mcp");
+    buildPromptVisibilityFilter = mod.buildPromptVisibilityFilter;
+  });
+
+  it("lets an authenticated owner see public prompts AND their own private ones", () => {
+    const filter = buildPromptVisibilityFilter({ id: "user-1" });
+    expect(filter).toEqual({
+      OR: [
+        { isPrivate: false },
+        { isPrivate: true, authorId: "user-1" },
+      ],
+    });
+  });
+
+  it("restricts unauthenticated callers to public prompts only", () => {
+    expect(buildPromptVisibilityFilter(null)).toEqual({ isPrivate: false });
+    expect(buildPromptVisibilityFilter(undefined)).toEqual({ isPrivate: false });
+  });
+
+  it("does not hard-filter isPrivate:false for an owner (regression: own private prompt was unfetchable)", () => {
+    const filter = buildPromptVisibilityFilter({ id: "owner" });
+    expect(filter).not.toHaveProperty("isPrivate", false);
+    expect(filter.OR).toContainEqual({ isPrivate: true, authorId: "owner" });
+  });
+});
+
 describe("MCP API handler - HTTP method routing", () => {
   let handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
 

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -96,6 +96,56 @@ function extractVariables(content: string): ExtractedVariable[] {
   return variables;
 }
 
+interface CategoryRow {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+/**
+ * Match a user-supplied category string against known categories.
+ * Tries, in order: exact slug (case-insensitive), exact name (case-insensitive),
+ * then slugified-name / slug equality (so "Code Review" and "code_review" both map
+ * to the "code-review" category). Returns null when nothing matches.
+ */
+export function findCategoryMatch(categories: CategoryRow[], input: string): CategoryRow | null {
+  const needle = input.trim().toLowerCase();
+  if (!needle) return null;
+
+  const bySlug = categories.find((c) => c.slug.toLowerCase() === needle);
+  if (bySlug) return bySlug;
+
+  const byName = categories.find((c) => c.name.toLowerCase() === needle);
+  if (byName) return byName;
+
+  const inputSlug = slugify(input);
+  const bySlugified = categories.find((c) => c.slug === inputSlug || slugify(c.name) === inputSlug);
+  if (bySlugified) return bySlugified;
+
+  return null;
+}
+
+/**
+ * Resolve a category string (slug or name) to a category id. Returns a human-readable
+ * warning (instead of silently dropping the value) when nothing matches, so callers can
+ * surface it rather than creating a prompt with no category and no feedback.
+ */
+async function resolveCategory(
+  category: string | undefined
+): Promise<{ categoryId: string | null; warning?: string }> {
+  if (!category) return { categoryId: null };
+
+  const categories = await db.category.findMany({ select: { id: true, name: true, slug: true } });
+  const match = findCategoryMatch(categories, category);
+  if (match) return { categoryId: match.id };
+
+  const available = categories.map((c) => c.slug).sort().join(", ");
+  return {
+    categoryId: null,
+    warning: `Category "${category}" did not match any category and was not assigned. Call list_categories, or pass one of these slugs: ${available || "(none)"}.`,
+  };
+}
+
 export const config = {
   api: {
     bodyParser: false,
@@ -349,6 +399,7 @@ function createServer(options: ServerOptions = {}) {
           type: p.type,
           author: p.author.name || p.author.username,
           category: p.category?.name || null,
+          categorySlug: p.category?.slug || null,
           tags: p.tags.map((t) => t.tag.name),
           votes: p._count.votes,
           createdAt: p.createdAt.toISOString(),
@@ -587,7 +638,7 @@ function createServer(options: ServerOptions = {}) {
         content: z.string().min(1).describe("The prompt content. Can include variables like ${variable} or ${variable:default}"),
         description: z.string().max(500).optional().describe("Optional description of the prompt"),
         tags: z.array(z.string()).max(10).optional().describe("Optional array of tag names (will be created if they don't exist)"),
-        category: z.string().optional().describe("Optional category slug"),
+        category: z.string().optional().describe("Optional category slug or name. Call list_categories for valid values; an unrecognized value is ignored (with a warning in the response) rather than failing the save."),
         isPrivate: z.boolean().optional().describe("Whether the prompt is private (default: uses your account setting)"),
         type: z.enum(["TEXT", "STRUCTURED", "IMAGE", "VIDEO", "AUDIO"]).optional().describe("Prompt type (default: TEXT)"),
         structuredFormat: z.enum(["JSON", "YAML"]).optional().describe("Format for structured prompts"),
@@ -625,12 +676,8 @@ function createServer(options: ServerOptions = {}) {
           }
         }
 
-        // Find category if provided
-        let categoryId: string | undefined;
-        if (category) {
-          const cat = await db.category.findUnique({ where: { slug: category } });
-          if (cat) categoryId = cat.id;
-        }
+        // Resolve category (accepts slug or name; warns instead of silently dropping)
+        const { categoryId, warning: categoryWarning } = await resolveCategory(category);
 
         // Create the prompt
         const prompt = await db.prompt.create({
@@ -668,10 +715,12 @@ function createServer(options: ServerOptions = {}) {
               type: "text" as const,
               text: JSON.stringify({
                   success: true,
+                  ...(categoryWarning ? { warning: categoryWarning } : {}),
                   prompt: {
                     ...prompt,
                     tags: prompt.tags.map((t) => t.tag.name),
                     category: prompt.category?.name || null,
+                    categorySlug: prompt.category?.slug || null,
                     link: prompt.isPrivate ? null : `https://prompts.chat/prompts/${prompt.id}_${getPromptName(prompt)}`,
                   },
                 }),
@@ -753,7 +802,7 @@ function createServer(options: ServerOptions = {}) {
           content: z.string().describe("File content"),
         })).min(1).describe("Array of files. Must include SKILL.md as the main skill file."),
         tags: z.array(z.string()).max(10).optional().describe("Optional array of tag names"),
-        category: z.string().optional().describe("Optional category slug"),
+        category: z.string().optional().describe("Optional category slug or name. Call list_categories for valid values; an unrecognized value is ignored (with a warning in the response) rather than failing the save."),
         isPrivate: z.boolean().optional().describe("Whether the skill is private (default: uses your account setting)"),
       },
     },
@@ -808,12 +857,8 @@ function createServer(options: ServerOptions = {}) {
           }
         }
 
-        // Find category if provided
-        let categoryId: string | undefined;
-        if (category) {
-          const cat = await db.category.findUnique({ where: { slug: category } });
-          if (cat) categoryId = cat.id;
-        }
+        // Resolve category (accepts slug or name; warns instead of silently dropping)
+        const { categoryId, warning: categoryWarning } = await resolveCategory(category);
 
         // Create the skill
         const skill = await db.prompt.create({
@@ -846,11 +891,13 @@ function createServer(options: ServerOptions = {}) {
               type: "text" as const,
               text: JSON.stringify({
                   success: true,
+                  ...(categoryWarning ? { warning: categoryWarning } : {}),
                   skill: {
                     ...skill,
                     files: files.map(f => f.filename),
                     tags: skill.tags.map((t) => t.tag.name),
                     category: skill.category?.name || null,
+                    categorySlug: skill.category?.slug || null,
                     link: skill.isPrivate ? null : `https://prompts.chat/prompts/${skill.id}_${getPromptName(skill)}`,
                   },
                 }),
@@ -1343,6 +1390,53 @@ function createServer(options: ServerOptions = {}) {
         console.error("MCP search_skills error:", error);
         return {
           content: [{ type: "text" as const, text: JSON.stringify({ error: "Failed to search skills" }) }],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // List categories tool - lets clients discover valid category slugs before saving
+  server.registerTool(
+    "list_categories",
+    {
+      title: "List Categories",
+      description:
+        "List all available prompt categories with their name and slug. Call this before save_prompt or save_skill so you can pass a valid `category` slug.",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const categories = await db.category.findMany({
+          orderBy: [{ order: "asc" }, { name: "asc" }],
+          select: {
+            name: true,
+            slug: true,
+            description: true,
+            _count: { select: { prompts: true } },
+          },
+        });
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                count: categories.length,
+                categories: categories.map((c) => ({
+                  name: c.name,
+                  slug: c.slug,
+                  description: c.description || null,
+                  promptCount: c._count.prompts,
+                })),
+              }),
+            },
+          ],
+        };
+      } catch (error) {
+        console.error("MCP list_categories error:", error);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ error: "Failed to list categories" }) }],
           isError: true,
         };
       }

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -126,6 +126,26 @@ export function findCategoryMatch(categories: CategoryRow[], input: string): Cat
 }
 
 /**
+ * Visibility filter for fetching a single prompt/skill by id: public entries, plus the
+ * authenticated owner's own private ones. Unauthenticated callers see only public entries.
+ * Returns a Prisma `where` fragment to spread into the query. Keep get_prompt and get_skill
+ * in sync — get_prompt previously hard-filtered `isPrivate: false`, hiding owners' own private
+ * prompts from themselves.
+ */
+export function buildPromptVisibilityFilter(
+  authenticatedUser: Pick<AuthenticatedUser, "id"> | null | undefined
+) {
+  return authenticatedUser
+    ? {
+        OR: [
+          { isPrivate: false },
+          { isPrivate: true, authorId: authenticatedUser.id },
+        ],
+      }
+    : { isPrivate: false };
+}
+
+/**
  * Resolve a category string (slug or name) to a category id. Returns a human-readable
  * warning (instead of silently dropping the value) when nothing matches, so callers can
  * surface it rather than creating a prompt with no category and no feedback.
@@ -438,12 +458,14 @@ function createServer(options: ServerOptions = {}) {
     },
     async ({ id, fill_variables }, extra) => {
       try {
+        const visibilityFilter = buildPromptVisibilityFilter(authenticatedUser);
+
         const prompt = await db.prompt.findFirst({
           where: {
             id,
-            isPrivate: false,
             isUnlisted: false,
             deletedAt: null,
+            ...visibilityFilter,
           },
           select: {
             id: true,
@@ -1214,15 +1236,7 @@ function createServer(options: ServerOptions = {}) {
     },
     async ({ id }) => {
       try {
-        // Build visibility filter
-        const visibilityFilter = authenticatedUser
-          ? {
-              OR: [
-                { isPrivate: false },
-                { isPrivate: true, authorId: authenticatedUser.id },
-              ],
-            }
-          : { isPrivate: false };
+        const visibilityFilter = buildPromptVisibilityFilter(authenticatedUser);
 
         const skill = await db.prompt.findFirst({
           where: {


### PR DESCRIPTION
Two small, self-contained fixes to the MCP server (`src/pages/api/mcp.ts`), each with tests.

### 1. `get_prompt` hides owners' own private prompts
`get_prompt` hard-filtered `isPrivate: false`, so an authenticated owner got **"Prompt not found"** when fetching their *own* private prompt — even though `get_skill` and `search_prompts` already surface owner-private entries. This was an inconsistency between the two read paths.

Extracted a shared `buildPromptVisibilityFilter(authenticatedUser)` →
`isPrivate:false OR (isPrivate:true AND authorId === me)` for authenticated callers, public-only otherwise — and applied it to **both** `get_prompt` and `get_skill` so they stay in sync.

### 2. `save_prompt` / `save_skill` silently drop unrecognized categories
Category was resolved by **exact slug only** (`findUnique({ where: { slug } })`); a category *name*, a differently-cased slug, or `code_review` vs `code-review` was silently ignored, creating an uncategorized prompt with no feedback.

- New `findCategoryMatch()` / `resolveCategory()` match by slug → name → slugified-name (all case-insensitive).
- On no match, the save still succeeds but the response includes a `warning` listing valid slugs, instead of silently dropping the value.
- New **`list_categories`** tool so clients can discover valid slugs before saving.
- Added `categorySlug` to `search_prompts` and to the `save_*` success payloads so a category can be round-tripped.

### Tests
`src/__tests__/api/mcp-handler.test.ts` adds unit coverage for `findCategoryMatch` (slug / name / slugify / whitespace / no-match) and `buildPromptVisibilityFilter` (including a regression test that an owner's filter does **not** hard-exclude their private prompts). All 17 tests pass.

No schema changes, no new dependencies, no breaking changes to existing tool signatures (the `category` arg now also accepts a name; previously-valid slugs behave identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Implemented MCP server fixes around prompt visibility and category handling.

- Fixed `get_prompt` so authenticated owners can access their own private prompts, while unauthenticated users still only see public prompts.
- Refactored prompt/skill visibility into a shared filter used by both `get_prompt` and `get_skill`.
- Improved category matching for `save_prompt` and `save_skill` to resolve by slug, name, or slugified name in a case-insensitive way.
- Added warnings when a category can’t be matched, while still allowing saves to succeed.
- Added `list_categories` for client-side category lookup.
- Included `categorySlug` in `search_prompts` and save success responses so category values can round-trip.
- Updated tests to cover category matching and visibility filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->