### PR TITLE
Add MiniMax-M3 and MiniMax-M2.7 to model registry

### DIFF
--- a/src/__tests__/lib/works-best-with.test.ts
+++ b/src/__tests__/lib/works-best-with.test.ts
@@ -30,6 +30,11 @@ describe("getModelInfo", () => {
     expect(getModelInfo("sora 2")).toEqual({ name: "Sora 2", provider: "OpenAI" });
     expect(getModelInfo("runway-gen4")).toEqual({ name: "Runway Gen-4", provider: "Runway" });
   });
+
+  it("returns correct info for MiniMax models", () => {
+    expect(getModelInfo("minimax-m3")).toEqual({ name: "MiniMax-M3", provider: "MiniMax" });
+    expect(getModelInfo("minimax-m2-7")).toEqual({ name: "MiniMax-M2.7", provider: "MiniMax" });
+  });
 });
 
 describe("isValidModelSlug", () => {

--- a/src/__tests__/lib/works-best-with.test.ts
+++ b/src/__tests__/lib/works-best-with.test.ts
@@ -61,6 +61,7 @@ describe("getModelsByProvider", () => {
     expect(grouped).toHaveProperty("Anthropic");
     expect(grouped).toHaveProperty("Google");
     expect(grouped).toHaveProperty("xAI");
+    expect(grouped).toHaveProperty("MiniMax");
   });
 
   it("includes all OpenAI models under OpenAI provider", () => {

--- a/src/lib/works-best-with.ts
+++ b/src/lib/works-best-with.ts
@@ -32,6 +32,9 @@ export const AI_MODELS = {
   "grok-4": { name: "Grok 4", provider: "xAI" },
   "grok-3": { name: "Grok 3", provider: "xAI" },
 
+  // MiniMax
+  "minimax-m3": { name: "MiniMax-M3", provider: "MiniMax" },
+
   // Image Generation
   "nano-banana": { name: "Nano Banana", provider: "Google" },
   "nano-banana-pro": { name: "Nano Banana Pro", provider: "Google" },

--- a/src/lib/works-best-with.ts
+++ b/src/lib/works-best-with.ts
@@ -34,6 +34,7 @@ export const AI_MODELS = {
 
   // MiniMax
   "minimax-m3": { name: "MiniMax-M3", provider: "MiniMax" },
+  "minimax-m2-7": { name: "MiniMax-M2.7", provider: "MiniMax" },
 
   // Image Generation
   "nano-banana": { name: "Nano Banana", provider: "Google" },


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry.

## Summary
- Register MiniMax-M3 and MiniMax-M2.7 under the MiniMax provider in the Works Best With model registry.
- Add exact lookup coverage for both registered models.

## Test plan
- `npm test -- src/__tests__/lib/works-best-with.test.ts`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added MiniMax-M3 to the Works Best With model registry (under the MiniMax provider) and extended the model-grouping/getModelInfo test expectations to include MiniMax models—verifying slugs like `minimax-m3` (and `minimax-m2-7`) return `{ name, provider: "MiniMax" }` and that `getModelsByProvider` groups results under the `MiniMax` provider key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->