### PR TITLE
Fix issue in prompts.chat source cleanup (#1129)

### DIFF
--- a/packages/prompts.chat/scripts/generate-docs.ts
+++ b/packages/prompts.chat/scripts/generate-docs.ts
@@ -43,10 +43,10 @@ function getJSDocComment(node: ts.Node, sourceFile: ts.SourceFile): { descriptio
   const jsDocNodes = (node as any).jsDoc as ts.JSDoc[] | undefined;
   if (jsDocNodes && jsDocNodes.length > 0) {
     const jsDoc = jsDocNodes[0];
-    
+
     if (jsDoc.comment) {
-      description = typeof jsDoc.comment === 'string' 
-        ? jsDoc.comment 
+      description = typeof jsDoc.comment === 'string'
+        ? jsDoc.comment
         : jsDoc.comment.map(c => c.text || '').join('');
     }
 
@@ -54,7 +54,7 @@ function getJSDocComment(node: ts.Node, sourceFile: ts.SourceFile): { descriptio
       for (const tag of jsDoc.tags) {
         const tagName = tag.tagName.text;
         let tagComment = '';
-        
+
         if (tag.comment) {
           tagComment = typeof tag.comment === 'string'
             ? tag.comment
@@ -85,13 +85,13 @@ function getTypeString(type: ts.TypeNode | undefined, sourceFile: ts.SourceFile)
 
 function parseFunction(node: ts.FunctionDeclaration | ts.MethodDeclaration | ts.ArrowFunction, sourceFile: ts.SourceFile, checker: ts.TypeChecker): DocEntry {
   const { description, tags, examples } = getJSDocComment(node, sourceFile);
-  
+
   const name = ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)
     ? node.name?.getText(sourceFile) || 'anonymous'
     : 'anonymous';
 
   const parameters: Array<{ name: string; type: string; description?: string; optional?: boolean; defaultValue?: string; isRest?: boolean }> = [];
-  
+
   for (const param of node.parameters) {
     const paramName = param.name.getText(sourceFile);
     const paramType = getTypeString(param.type, sourceFile);
@@ -136,7 +136,7 @@ function parseInterface(node: ts.InterfaceDeclaration, sourceFile: ts.SourceFile
   const name = node.name.getText(sourceFile);
 
   const properties: DocEntry[] = [];
-  
+
   for (const member of node.members) {
     if (ts.isPropertySignature(member)) {
       const propName = member.name.getText(sourceFile);
@@ -247,7 +247,7 @@ function parseVariableStatement(node: ts.VariableStatement, sourceFile: ts.Sourc
   for (const decl of node.declarationList.declarations) {
     const name = decl.name.getText(sourceFile);
     let signature = name;
-    
+
     if (decl.type) {
       signature += `: ${decl.type.getText(sourceFile)}`;
     } else if (decl.initializer) {
@@ -265,18 +265,18 @@ function parseVariableStatement(node: ts.VariableStatement, sourceFile: ts.Sourc
         if (ts.isPropertyAssignment(prop) && prop.name) {
           const propName = prop.name.getText(sourceFile);
           const { description: propDesc, tags: propTags, examples: propExamples } = getJSDocComment(prop, sourceFile);
-          
+
           // Handle arrow functions and function expressions
           if (ts.isArrowFunction(prop.initializer) || ts.isFunctionExpression(prop.initializer)) {
             const fn = prop.initializer;
             const params: Array<{ name: string; type: string; description?: string; optional?: boolean; defaultValue?: string }> = [];
-            
+
             for (const param of fn.parameters) {
               const paramName = param.name.getText(sourceFile);
               const paramType = getTypeString(param.type, sourceFile);
               const optional = !!param.questionToken || !!param.initializer;
               const defaultValue = param.initializer?.getText(sourceFile);
-              
+
               params.push({
                 name: paramName,
                 type: paramType,
@@ -285,13 +285,13 @@ function parseVariableStatement(node: ts.VariableStatement, sourceFile: ts.Sourc
                 defaultValue,
               });
             }
-            
+
             const returnType = getTypeString(fn.type, sourceFile);
             const paramSignature = params
               .map(p => `${p.name}${p.optional ? '?' : ''}: ${p.type}`)
               .join(', ');
             const methodSignature = `${propName}(${paramSignature}): ${returnType}`;
-            
+
             methods.push({
               name: propName,
               kind: 'method',
@@ -332,7 +332,7 @@ function parseSourceFile(filePath: string, program: ts.Program): ModuleDoc {
 
   const checker = program.getTypeChecker();
   const exports: DocEntry[] = [];
-  
+
   // Get module-level JSDoc if any
   let moduleDescription: string | undefined;
   const firstStatement = sourceFile.statements[0];
@@ -396,7 +396,7 @@ function parseSourceFile(filePath: string, program: ts.Program): ModuleDoc {
 
 function generateMarkdown(modules: ModuleDoc[]): string {
   const lines: string[] = [];
-  
+
   lines.push('# API Reference\n');
   lines.push('> Auto-generated from TypeScript source files\n');
 
@@ -416,7 +416,7 @@ function generateMarkdown(modules: ModuleDoc[]): string {
   for (const mod of modules) {
     lines.push(`---\n`);
     lines.push(`## ${mod.name}\n`);
-    
+
     if (mod.description) {
       lines.push(`${mod.description}\n`);
     }
@@ -570,7 +570,7 @@ function generateMarkdown(modules: ModuleDoc[]): string {
 // Generate TypeScript file for IDE sidebar
 function generateSidebarTS(modules: ModuleDoc[]): string {
   const lines: string[] = [];
-  
+
   lines.push('/**');
   lines.push(' * Auto-generated API documentation for IDE sidebar');
   lines.push(' * Generated from TypeScript source files via reflection');
@@ -634,7 +634,7 @@ function generateSidebarTS(modules: ModuleDoc[]): string {
     if (groupModules.length === 0) continue;
 
     const items: string[] = [];
-    
+
     for (const mod of groupModules) {
       // Add functions
       const functions = mod.exports.filter(e => e.kind === 'function');
@@ -644,7 +644,7 @@ function generateSidebarTS(modules: ModuleDoc[]): string {
           type: p.type,
           description: p.description || undefined,
         })) || [];
-        
+
         items.push(`    {
       name: "${fn.name}()",
       type: "function",
@@ -664,7 +664,7 @@ function generateSidebarTS(modules: ModuleDoc[]): string {
       type: "class",
       description: ${JSON.stringify(cls.description || '')},
     }`);
-        
+
         // Add class methods
         if (cls.methods) {
           for (const method of cls.methods) {
@@ -673,7 +673,7 @@ function generateSidebarTS(modules: ModuleDoc[]): string {
               type: p.type,
               description: p.description || undefined,
             })) || [];
-            
+
             items.push(`    {
       name: ".${method.name}()",
       type: "method",
@@ -716,7 +716,7 @@ function generateSidebarTS(modules: ModuleDoc[]): string {
       signature: ${JSON.stringify(v.signature || '')},
       description: ${JSON.stringify(v.description || '')},
     }`);
-        
+
         // Add methods from object literals (like templates)
         if (v.methods) {
           for (const method of v.methods) {
@@ -725,7 +725,7 @@ function generateSidebarTS(modules: ModuleDoc[]): string {
               type: p.type,
               description: p.description || undefined,
             })) || [];
-            
+
             items.push(`    {
       name: "${v.name}.${method.name}()",
       type: "method",
@@ -751,14 +751,14 @@ function generateSidebarTS(modules: ModuleDoc[]): string {
 
   lines.push('];');
   lines.push('');
-  
+
   return lines.join('\n');
 }
 
 // Generate TypeScript declaration file content for Monaco editor
 function generateTypeDefinitions(modules: ModuleDoc[]): string {
   const lines: string[] = [];
-  
+
   lines.push('/**');
   lines.push(' * Auto-generated type definitions for prompts.chat');
   lines.push(' * Generated from TypeScript source files via reflection');
@@ -825,10 +825,10 @@ function generateTypeDefinitions(modules: ModuleDoc[]): string {
   // Process each module
   const processModule = (mod: ModuleDoc | undefined, sectionComment: string) => {
     if (!mod) return;
-    
+
     lines.push('');
     lines.push(`  // ${sectionComment}`);
-    
+
     // Types first (skip duplicates)
     for (const entry of mod.exports.filter(e => e.kind === 'type')) {
       if (addedTypes.has(entry.name)) continue;
@@ -838,7 +838,7 @@ function generateTypeDefinitions(modules: ModuleDoc[]): string {
         addedTypes.add(entry.name);
       }
     }
-    
+
     // Interfaces (skip duplicates)
     for (const entry of mod.exports.filter(e => e.kind === 'interface')) {
       if (addedInterfaces.has(entry.name)) continue;
@@ -848,7 +848,7 @@ function generateTypeDefinitions(modules: ModuleDoc[]): string {
         addedInterfaces.add(entry.name);
       }
     }
-    
+
     // Classes (skip duplicates)
     for (const entry of mod.exports.filter(e => e.kind === 'class')) {
       if (addedClasses.has(entry.name)) continue;
@@ -858,7 +858,7 @@ function generateTypeDefinitions(modules: ModuleDoc[]): string {
         addedClasses.add(entry.name);
       }
     }
-    
+
     // Functions (skip duplicates)
     for (const entry of mod.exports.filter(e => e.kind === 'function')) {
       if (addedFunctions.has(entry.name)) continue;
@@ -876,7 +876,7 @@ function generateTypeDefinitions(modules: ModuleDoc[]): string {
   processModule(audioModule, 'AUDIO BUILDER TYPES');
   processModule(videoModule, 'VIDEO BUILDER TYPES');
   processModule(mediaModule, 'IMAGE BUILDER TYPES');
-  
+
   // Generate templates namespace from object literal methods
   if (builderModule) {
     const templatesVar = builderModule.exports.find(e => e.kind === 'variable' && e.name === 'templates');
@@ -945,7 +945,7 @@ function generateTypeDefinitions(modules: ModuleDoc[]): string {
   lines.push('}');
   lines.push('`;');
   lines.push('');
-  
+
   return lines.join('\n');
 }
 
@@ -954,10 +954,10 @@ function extractStringLiteralOptions(program: ts.Program, files: string[]): { me
   // Phase 1: Collect all type aliases and interface properties
   const typeAliases: Record<string, string[]> = {};
   const interfaceProps: Record<string, Record<string, string[]>> = {}; // InterfaceName -> { propName -> literals }
-  
+
   function extractLiteralsFromType(type: ts.TypeNode, sourceFile: ts.SourceFile): string[] {
     const literals: string[] = [];
-    
+
     if (ts.isUnionTypeNode(type)) {
       for (const member of type.types) {
         if (ts.isLiteralTypeNode(member) && member.literal && ts.isStringLiteral(member.literal)) {
@@ -969,7 +969,7 @@ function extractStringLiteralOptions(program: ts.Program, files: string[]): { me
     } else if (ts.isLiteralTypeNode(type) && type.literal && ts.isStringLiteral(type.literal)) {
       literals.push(type.literal.text);
     }
-    
+
     return literals;
   }
 
@@ -991,7 +991,7 @@ function extractStringLiteralOptions(program: ts.Program, files: string[]): { me
       if (ts.isInterfaceDeclaration(node)) {
         const interfaceName = node.name.getText(sf);
         interfaceProps[interfaceName] = interfaceProps[interfaceName] || {};
-        
+
         for (const member of node.members) {
           if (ts.isPropertySignature(member) && member.name && member.type) {
             const propName = member.name.getText(sf);
@@ -1022,15 +1022,15 @@ function extractStringLiteralOptions(program: ts.Program, files: string[]): { me
         for (const member of node.members) {
           if (ts.isMethodDeclaration(member) && member.name) {
             const methodName = member.name.getText(sf);
-            
+
             for (const param of member.parameters) {
               if (!param.type) continue;
-              
+
               let literals: string[] = [];
-              
+
               // Direct literal union in parameter
               literals = extractLiteralsFromType(param.type, sf);
-              
+
               // Type reference (e.g., MusicGenre)
               if (literals.length === 0 && ts.isTypeReferenceNode(param.type)) {
                 const refName = param.type.typeName.getText(sf);
@@ -1038,12 +1038,12 @@ function extractStringLiteralOptions(program: ts.Program, files: string[]): { me
                   literals = typeAliases[refName];
                 }
               }
-              
+
               // Indexed access type (e.g., AudioTempo['feel'])
               if (literals.length === 0 && ts.isIndexedAccessTypeNode(param.type)) {
                 const objectType = param.type.objectType;
                 const indexType = param.type.indexType;
-                
+
                 if (ts.isTypeReferenceNode(objectType) && ts.isLiteralTypeNode(indexType)) {
                   const interfaceName = objectType.typeName.getText(sf);
                   if (indexType.literal && ts.isStringLiteral(indexType.literal)) {
@@ -1054,7 +1054,7 @@ function extractStringLiteralOptions(program: ts.Program, files: string[]): { me
                   }
                 }
               }
-              
+
               // Union containing type references (e.g., MusicGenre | AudioGenre)
               if (literals.length === 0 && ts.isUnionTypeNode(param.type)) {
                 for (const member of param.type.types) {
@@ -1066,7 +1066,7 @@ function extractStringLiteralOptions(program: ts.Program, files: string[]): { me
                   }
                 }
               }
-              
+
               if (literals.length > 0) {
                 // Deduplicate
                 const uniqueLiterals = [...new Set(literals)];
@@ -1091,29 +1091,29 @@ function extractStringLiteralOptions(program: ts.Program, files: string[]): { me
 // Generate type options mapping (TypeName -> valid values) for error messages
 function generateTypeOptions(typeAliases: Record<string, string[]>): string {
   const lines: string[] = [];
-  
+
   lines.push('');
   lines.push('// Type name to valid options mapping for enhanced error messages');
   lines.push('export const TYPE_OPTIONS: Record<string, string[]> = {');
-  
+
   // Sort keys for consistent output
   const sortedKeys = Object.keys(typeAliases).sort();
-  
+
   for (const key of sortedKeys) {
     if (typeAliases[key].length > 0) {
       lines.push(`  ${JSON.stringify(key)}: ${JSON.stringify(typeAliases[key])},`);
     }
   }
-  
+
   lines.push('};');
-  
+
   return lines.join('\n');
 }
 
 // Generate method options file for Monaco autocomplete
 function generateMethodOptions(options: Record<string, string[]>): string {
   const lines: string[] = [];
-  
+
   lines.push('/**');
   lines.push(' * Auto-generated method options for Monaco autocomplete');
   lines.push(' * Generated from TypeScript source files via reflection');
@@ -1121,10 +1121,10 @@ function generateMethodOptions(options: Record<string, string[]>): string {
   lines.push(' */');
   lines.push('');
   lines.push('export const METHOD_OPTIONS: Record<string, string[]> = {');
-  
+
   // Collect all method names with their values, avoiding duplicates
   const methodMap: Record<string, string[]> = {};
-  
+
   // Common method name aliases (type name -> method name)
   const methodAliases: Record<string, string[]> = {
     musicGenre: ['genre'],
@@ -1150,17 +1150,17 @@ function generateMethodOptions(options: Record<string, string[]>): string {
     sensorFormat: ['sensor'],
     songSection: ['section'],
   };
-  
+
   for (const [key, values] of Object.entries(options)) {
     if (values.length > 0) {
       // Convert type names to likely method names (camelCase, remove 'Type' suffix)
       const methodName = key.charAt(0).toLowerCase() + key.slice(1).replace(/Type$/, '');
-      
+
       // Keep the longer list if there's a conflict
       if (!methodMap[methodName] || methodMap[methodName].length < values.length) {
         methodMap[methodName] = values;
       }
-      
+
       // Also add aliases
       const aliases = methodAliases[methodName] || [];
       for (const alias of aliases) {
@@ -1170,17 +1170,17 @@ function generateMethodOptions(options: Record<string, string[]>): string {
       }
     }
   }
-  
+
   // Sort keys for consistent output
   const sortedKeys = Object.keys(methodMap).sort();
-  
+
   for (const key of sortedKeys) {
     lines.push(`  ${JSON.stringify(key)}: ${JSON.stringify(methodMap[key])},`);
   }
-  
+
   lines.push('};');
   lines.push('');
-  
+
   return lines.join('\n');
 }
 

--- a/packages/prompts.chat/src/builder/audio.ts
+++ b/packages/prompts.chat/src/builder/audio.ts
@@ -1,12 +1,12 @@
 /**
  * Audio/Music Prompt Builder - Comprehensive music generation prompt builder
- * 
+ *
  * Based on Suno, Udio, and other music generation best practices.
- * 
+ *
  * @example
  * ```ts
  * import { audio } from 'prompts.chat/builder';
- * 
+ *
  * const prompt = audio()
  *   .genre("synthwave")
  *   .mood("nostalgic", "dreamy")
@@ -23,7 +23,7 @@ import type { Mood, OutputFormat } from './media';
 // AUDIO-SPECIFIC TYPES
 // ============================================================================
 
-export type MusicGenre = 
+export type MusicGenre =
   | 'pop' | 'rock' | 'jazz' | 'classical' | 'electronic' | 'hip-hop' | 'r&b'
   | 'country' | 'folk' | 'blues' | 'metal' | 'punk' | 'indie' | 'alternative'
   | 'ambient' | 'lo-fi' | 'synthwave' | 'orchestral' | 'cinematic' | 'world'
@@ -32,7 +32,7 @@ export type MusicGenre =
   | 'shoegaze' | 'post-rock' | 'prog-rock' | 'psychedelic' | 'chillwave'
   | 'vaporwave' | 'drum-and-bass' | 'dubstep' | 'trance' | 'hardcore';
 
-export type Instrument = 
+export type Instrument =
   | 'piano' | 'guitar' | 'acoustic-guitar' | 'electric-guitar' | 'bass' | 'drums'
   | 'violin' | 'cello' | 'viola' | 'flute' | 'saxophone' | 'trumpet' | 'trombone'
   | 'synthesizer' | 'organ' | 'harp' | 'percussion' | 'strings' | 'brass' | 'woodwinds'
@@ -41,7 +41,7 @@ export type Instrument =
   | 'congas' | 'bongos' | 'djembe' | 'tabla' | 'sitar' | 'erhu' | 'koto'
   | '808' | '909' | 'moog' | 'rhodes' | 'wurlitzer' | 'mellotron' | 'theremin';
 
-export type VocalStyle = 
+export type VocalStyle =
   | 'male' | 'female' | 'duet' | 'choir' | 'a-cappella' | 'spoken-word' | 'rap'
   | 'falsetto' | 'belting' | 'whisper' | 'growl' | 'melodic' | 'harmonized'
   | 'auto-tuned' | 'operatic' | 'soul' | 'breathy' | 'nasal' | 'raspy' | 'clear';
@@ -51,18 +51,18 @@ export type VocalLanguage =
   | 'japanese' | 'korean' | 'chinese' | 'arabic' | 'hindi' | 'russian' | 'turkish'
   | 'instrumental';
 
-export type TempoMarking = 
+export type TempoMarking =
   | 'largo' | 'adagio' | 'andante' | 'moderato' | 'allegro' | 'vivace' | 'presto';
 
 export type TimeSignature = '4/4' | '3/4' | '6/8' | '2/4' | '5/4' | '7/8' | '12/8';
 
-export type MusicalKey = 
-  | 'C' | 'C#' | 'Db' | 'D' | 'D#' | 'Eb' | 'E' | 'F' | 'F#' | 'Gb' 
+export type MusicalKey =
+  | 'C' | 'C#' | 'Db' | 'D' | 'D#' | 'Eb' | 'E' | 'F' | 'F#' | 'Gb'
   | 'G' | 'G#' | 'Ab' | 'A' | 'A#' | 'Bb' | 'B'
-  | 'Cm' | 'C#m' | 'Dm' | 'D#m' | 'Ebm' | 'Em' | 'Fm' | 'F#m' 
+  | 'Cm' | 'C#m' | 'Dm' | 'D#m' | 'Ebm' | 'Em' | 'Fm' | 'F#m'
   | 'Gm' | 'G#m' | 'Am' | 'A#m' | 'Bbm' | 'Bm';
 
-export type SongSection = 
+export type SongSection =
   | 'intro' | 'verse' | 'pre-chorus' | 'chorus' | 'bridge' | 'breakdown'
   | 'drop' | 'build-up' | 'outro' | 'solo' | 'interlude' | 'hook';
 
@@ -202,8 +202,8 @@ export class AudioPromptBuilder {
   }
 
   fusion(genres: MusicGenre[]): this {
-    this._genre = { 
-      ...(this._genre || { primary: 'pop' }), 
+    this._genre = {
+      ...(this._genre || { primary: 'pop' }),
       secondary: genres,
       fusion: genres as string[],
     };
@@ -213,8 +213,8 @@ export class AudioPromptBuilder {
   // --- Mood Methods ---
 
   mood(primary: Mood | string, ...secondary: (Mood | string)[]): this {
-    this._mood = { 
-      primary, 
+    this._mood = {
+      primary,
       secondary: secondary.length ? secondary : undefined,
     };
     return this;
@@ -296,8 +296,8 @@ export class AudioPromptBuilder {
   // --- Instrumentation Methods ---
 
   instruments(instruments: Instrument[]): this {
-    this._instrumentation = { 
-      ...(this._instrumentation || {}), 
+    this._instrumentation = {
+      ...(this._instrumentation || {}),
       lead: instruments,
     };
     return this;
@@ -482,7 +482,7 @@ export class AudioPromptBuilder {
     if (this._instrumentation) {
       const instrParts: string[] = [];
       if (this._instrumentation.lead) {
-        const leads = Array.isArray(this._instrumentation.lead) 
+        const leads = Array.isArray(this._instrumentation.lead)
           ? this._instrumentation.lead : [this._instrumentation.lead];
         instrParts.push(leads.join(', '));
       }
@@ -499,7 +499,7 @@ export class AudioPromptBuilder {
         vocalParts.push('instrumental');
       } else {
         if (this._vocals.style) {
-          const styles = Array.isArray(this._vocals.style) 
+          const styles = Array.isArray(this._vocals.style)
             ? this._vocals.style : [this._vocals.style];
           vocalParts.push(`${styles.join(' and ')} vocals`);
         }
@@ -514,7 +514,7 @@ export class AudioPromptBuilder {
     if (this._production) {
       const prodParts: string[] = [];
       if (this._production.style) {
-        const styles = Array.isArray(this._production.style) 
+        const styles = Array.isArray(this._production.style)
           ? this._production.style : [this._production.style];
         prodParts.push(`${styles.join(', ')} production`);
       }
@@ -620,13 +620,13 @@ export class AudioPromptBuilder {
   toMarkdown(): string {
     const built = this.build();
     const sections: string[] = ['# Audio Prompt\n'];
-    
+
     sections.push('## Style Prompt\n```\n' + built.stylePrompt + '\n```\n');
-    
+
     if (built.lyricsPrompt) {
       sections.push('## Lyrics\n```\n' + built.lyricsPrompt + '\n```\n');
     }
-    
+
     if (built.structure.genre) {
       sections.push('## Genre\n' + objectToMarkdownList(built.structure.genre));
     }
@@ -645,7 +645,7 @@ export class AudioPromptBuilder {
     if (built.structure.production) {
       sections.push('## Production\n' + objectToMarkdownList(built.structure.production));
     }
-    
+
     return sections.join('\n');
   }
 
@@ -666,10 +666,10 @@ export class AudioPromptBuilder {
 function objectToYaml(obj: object, indent = 0): string {
   const spaces = '  '.repeat(indent);
   const lines: string[] = [];
-  
+
   for (const [key, value] of Object.entries(obj)) {
     if (value === undefined || value === null) continue;
-    
+
     if (Array.isArray(value)) {
       if (value.length === 0) continue;
       lines.push(`${spaces}${key}:`);
@@ -688,17 +688,17 @@ function objectToYaml(obj: object, indent = 0): string {
       lines.push(`${spaces}${key}: ${value}`);
     }
   }
-  
+
   return lines.join('\n');
 }
 
 function objectToMarkdownList(obj: object, indent = 0): string {
   const spaces = '  '.repeat(indent);
   const lines: string[] = [];
-  
+
   for (const [key, value] of Object.entries(obj)) {
     if (value === undefined || value === null) continue;
-    
+
     if (Array.isArray(value)) {
       lines.push(`${spaces}- **${key}:** ${value.join(', ')}`);
     } else if (typeof value === 'object') {
@@ -708,7 +708,7 @@ function objectToMarkdownList(obj: object, indent = 0): string {
       lines.push(`${spaces}- **${key}:** ${value}`);
     }
   }
-  
+
   return lines.join('\n');
 }
 

--- a/packages/prompts.chat/src/builder/chat.ts
+++ b/packages/prompts.chat/src/builder/chat.ts
@@ -1,13 +1,13 @@
 /**
  * Chat Prompt Builder - Model-Agnostic Conversation Prompt Builder
- * 
+ *
  * Build structured prompts for any chat/conversation model.
  * Focus on prompt engineering, not model-specific features.
- * 
+ *
  * @example
  * ```ts
  * import { chat } from 'prompts.chat/builder';
- * 
+ *
  * const prompt = chat()
  *   .role("helpful coding assistant")
  *   .context("Building a React application")
@@ -47,21 +47,21 @@ export interface ResponseFormat {
 }
 
 // --- Persona Types ---
-export type PersonaTone = 
+export type PersonaTone =
   | 'professional' | 'casual' | 'formal' | 'friendly' | 'academic'
   | 'technical' | 'creative' | 'empathetic' | 'authoritative' | 'playful'
   | 'concise' | 'detailed' | 'socratic' | 'coaching' | 'analytical'
   | 'encouraging' | 'neutral' | 'humorous' | 'serious';
 
-export type PersonaExpertise = 
+export type PersonaExpertise =
   | 'general' | 'coding' | 'writing' | 'analysis' | 'research'
   | 'teaching' | 'counseling' | 'creative' | 'legal' | 'medical'
   | 'financial' | 'scientific' | 'engineering' | 'design' | 'marketing'
   | 'business' | 'philosophy' | 'history' | 'languages' | 'mathematics';
 
 // --- Reasoning Types ---
-export type ReasoningStyle = 
-  | 'step-by-step' | 'chain-of-thought' | 'tree-of-thought' 
+export type ReasoningStyle =
+  | 'step-by-step' | 'chain-of-thought' | 'tree-of-thought'
   | 'direct' | 'analytical' | 'comparative' | 'deductive' | 'inductive'
   | 'first-principles' | 'analogical' | 'devil-advocate';
 
@@ -363,35 +363,35 @@ export class ChatPromptBuilder {
   }
 
   outputFormat(format: ResponseFormatType): this {
-    this._output = { 
-      ...(this._output || {}), 
-      format: { type: format } 
+    this._output = {
+      ...(this._output || {}),
+      format: { type: format }
     };
     return this;
   }
 
   json(schema?: JsonSchema): this {
     if (schema) {
-      this._output = { 
-        ...(this._output || {}), 
-        format: { type: 'json', jsonSchema: schema } 
+      this._output = {
+        ...(this._output || {}),
+        format: { type: 'json', jsonSchema: schema }
       };
     } else {
-      this._output = { 
-        ...(this._output || {}), 
-        format: { type: 'json' } 
+      this._output = {
+        ...(this._output || {}),
+        format: { type: 'json' }
       };
     }
     return this;
   }
 
   jsonSchema(name: string, schema: Record<string, unknown>, description?: string): this {
-    this._output = { 
-      ...(this._output || {}), 
-      format: { 
-        type: 'json', 
-        jsonSchema: { name, schema, description } 
-      } 
+    this._output = {
+      ...(this._output || {}),
+      format: {
+        type: 'json',
+        jsonSchema: { name, schema, description }
+      }
     };
     return this;
   }
@@ -573,21 +573,21 @@ export class ChatPromptBuilder {
       } else if (this._persona.role) {
         personaText += `You are ${this._persona.role}.`;
       }
-      
+
       if (this._persona.tone) {
         const tones = Array.isArray(this._persona.tone) ? this._persona.tone : [this._persona.tone];
         personaText += ` Your tone is ${tones.join(' and ')}.`;
       }
-      
+
       if (this._persona.expertise) {
         const areas = Array.isArray(this._persona.expertise) ? this._persona.expertise : [this._persona.expertise];
         personaText += ` You have expertise in ${areas.join(', ')}.`;
       }
-      
+
       if (this._persona.personality?.length) {
         personaText += ` You are ${this._persona.personality.join(', ')}.`;
       }
-      
+
       if (this._persona.background) {
         personaText += ` ${this._persona.background}`;
       }
@@ -606,7 +606,7 @@ export class ChatPromptBuilder {
     // Context
     if (this._context) {
       const contextParts: string[] = [];
-      
+
       if (this._context.background) {
         contextParts.push(this._context.background);
       }
@@ -625,7 +625,7 @@ export class ChatPromptBuilder {
       if (this._context.assumptions?.length) {
         contextParts.push(`Assumptions:\n${this._context.assumptions.map(a => `- ${a}`).join('\n')}`);
       }
-      
+
       if (contextParts.length) {
         parts.push(`## Context\n${contextParts.join('\n')}`);
       }
@@ -634,7 +634,7 @@ export class ChatPromptBuilder {
     // Task
     if (this._task) {
       const taskParts: string[] = [];
-      
+
       if (this._task.instruction) {
         taskParts.push(this._task.instruction);
       }
@@ -653,7 +653,7 @@ export class ChatPromptBuilder {
       if (this._task.antiPatterns?.length) {
         taskParts.push(`\nAvoid:\n${this._task.antiPatterns.map(a => `- ${a}`).join('\n')}`);
       }
-      
+
       if (taskParts.length) {
         parts.push(`## Task\n${taskParts.join('\n')}`);
       }
@@ -679,7 +679,7 @@ export class ChatPromptBuilder {
     // Output format
     if (this._output) {
       const outputParts: string[] = [];
-      
+
       if (this._output.format) {
         switch (this._output.format.type) {
           case 'json':
@@ -731,7 +731,7 @@ export class ChatPromptBuilder {
       if (this._output.includeConfidence) {
         outputParts.push('Include your confidence level in the answer.');
       }
-      
+
       if (outputParts.length) {
         parts.push(`## Output Format\n${outputParts.join('\n')}`);
       }
@@ -740,7 +740,7 @@ export class ChatPromptBuilder {
     // Reasoning
     if (this._reasoning) {
       const reasoningParts: string[] = [];
-      
+
       if (this._reasoning.style) {
         const styleInstructions: Record<ReasoningStyle, string> = {
           'step-by-step': 'Think through this step by step.',
@@ -769,7 +769,7 @@ export class ChatPromptBuilder {
       if (this._reasoning.explainAssumptions) {
         reasoningParts.push('Explicitly state any assumptions you make.');
       }
-      
+
       if (reasoningParts.length) {
         parts.push(`## Reasoning\n${reasoningParts.join('\n')}`);
       }
@@ -778,7 +778,7 @@ export class ChatPromptBuilder {
     // Memory
     if (this._memory) {
       const memoryParts: string[] = [];
-      
+
       if (this._memory.summary) {
         memoryParts.push(`Previous conversation summary: ${this._memory.summary}`);
       }
@@ -788,7 +788,7 @@ export class ChatPromptBuilder {
       if (this._memory.preferences?.length) {
         memoryParts.push(`User preferences:\n${this._memory.preferences.map(p => `- ${p}`).join('\n')}`);
       }
-      
+
       if (memoryParts.length) {
         parts.push(`## Memory\n${memoryParts.join('\n')}`);
       }
@@ -804,16 +804,16 @@ export class ChatPromptBuilder {
 
   build(): BuiltChatPrompt {
     const systemPrompt = this.buildSystemPrompt();
-    
+
     // Ensure system message is first
     let messages = [...this._messages];
     const hasSystemMessage = messages.some(m => m.role === 'system');
-    
+
     if (systemPrompt && !hasSystemMessage) {
       messages = [{ role: 'system', content: systemPrompt }, ...messages];
     } else if (systemPrompt && hasSystemMessage) {
       // Prepend built system prompt to existing system message
-      messages = messages.map(m => 
+      messages = messages.map(m =>
         m.role === 'system' ? { ...m, content: `${systemPrompt}\n\n${m.content}` } : m
       );
     }
@@ -869,9 +869,9 @@ export class ChatPromptBuilder {
   toMarkdown(): string {
     const built = this.build();
     const sections: string[] = ['# Chat Prompt\n'];
-    
+
     sections.push('## System Prompt\n```\n' + built.systemPrompt + '\n```\n');
-    
+
     if (built.messages.length > 1) {
       sections.push('## Messages\n');
       for (const msg of built.messages) {
@@ -879,7 +879,7 @@ export class ChatPromptBuilder {
         sections.push(`**${msg.role.toUpperCase()}${msg.name ? ` (${msg.name})` : ''}:**\n${msg.content}\n`);
       }
     }
-    
+
     return sections.join('\n');
   }
 }
@@ -891,10 +891,10 @@ export class ChatPromptBuilder {
 function objectToYaml(obj: object, indent = 0): string {
   const spaces = '  '.repeat(indent);
   const lines: string[] = [];
-  
+
   for (const [key, value] of Object.entries(obj)) {
     if (value === undefined || value === null) continue;
-    
+
     if (Array.isArray(value)) {
       if (value.length === 0) continue;
       lines.push(`${spaces}${key}:`);
@@ -918,7 +918,7 @@ function objectToYaml(obj: object, indent = 0): string {
       lines.push(`${spaces}${key}: ${value}`);
     }
   }
-  
+
   return lines.join('\n');
 }
 
@@ -946,11 +946,11 @@ export const chatPresets = {
       .role("expert software developer")
       .expertise("coding")
       .tone("technical");
-    
+
     if (language) {
       c.context(`Programming language: ${language}`);
     }
-    
+
     return c;
   },
 
@@ -961,11 +961,11 @@ export const chatPresets = {
     const c = chat()
       .role("skilled writer and editor")
       .expertise("writing");
-    
+
     if (style) {
       c.tone(style === 'creative' ? 'creative' : style === 'academic' ? 'academic' : 'professional');
     }
-    
+
     return c;
   },
 
@@ -979,11 +979,11 @@ export const chatPresets = {
       .tone(['friendly', 'empathetic'])
       .stepByStep()
       .withExamples();
-    
+
     if (subject) {
       c.domain(subject);
     }
-    
+
     return c;
   },
 

--- a/packages/prompts.chat/src/builder/index.ts
+++ b/packages/prompts.chat/src/builder/index.ts
@@ -1,10 +1,10 @@
 /**
  * Prompt Builder - A fluent DSL for creating structured prompts
- * 
+ *
  * @example
  * ```ts
  * import { builder } from 'prompts.chat';
- * 
+ *
  * const prompt = builder()
  *   .role("Senior TypeScript Developer")
  *   .context("You are helping review code")
@@ -150,7 +150,7 @@ export class PromptBuilder {
    * Define a variable placeholder
    */
   variable(
-    name: string, 
+    name: string,
     options: { description?: string; required?: boolean; defaultValue?: string } = {}
   ): this {
     this._variables.push({
@@ -237,7 +237,7 @@ export class PromptBuilder {
     if (this._variables.length > 0) {
       const varsText = this._variables
         .map(v => {
-          const placeholder = v.defaultValue 
+          const placeholder = v.defaultValue
             ? `\${${v.name}:${v.defaultValue}}`
             : `\${${v.name}}`;
           const desc = v.description ? ` - ${v.description}` : '';
@@ -286,11 +286,11 @@ export function fromPrompt(content: string): PromptBuilder {
 
 // Re-export media builders
 export { image, ImagePromptBuilder } from './media';
-export type { 
-  BuiltImagePrompt, 
-  ImageSubject, 
-  ImageCamera, 
-  ImageLighting, 
+export type {
+  BuiltImagePrompt,
+  ImageSubject,
+  ImageCamera,
+  ImageLighting,
   ImageComposition,
   ImageStyle,
   ImageColor,
@@ -309,7 +309,7 @@ export type {
 } from './media';
 
 export { video, VideoPromptBuilder } from './video';
-export type { 
+export type {
   BuiltVideoPrompt,
   VideoScene,
   VideoSubject,

--- a/packages/prompts.chat/src/builder/media.ts
+++ b/packages/prompts.chat/src/builder/media.ts
@@ -1,13 +1,13 @@
 /**
  * Media Prompt Builders - The D3.js of Prompt Building
- * 
+ *
  * Comprehensive, structured builders for Image, Video, and Audio generation prompts.
  * Every attribute a professional would consider is available as a chainable method.
- * 
+ *
  * @example
  * ```ts
  * import { image, video, audio } from 'prompts.chat/builder';
- * 
+ *
  * const imagePrompt = image()
  *   .subject("a lone samurai")
  *   .environment("bamboo forest at dawn")
@@ -25,11 +25,11 @@
 export type OutputFormat = 'text' | 'json' | 'yaml' | 'markdown';
 
 // --- Camera Brands & Models ---
-export type CameraBrand = 
+export type CameraBrand =
   | 'sony' | 'canon' | 'nikon' | 'fujifilm' | 'leica' | 'hasselblad' | 'phase-one'
   | 'panasonic' | 'olympus' | 'pentax' | 'red' | 'arri' | 'blackmagic' | 'panavision';
 
-export type CameraModel = 
+export type CameraModel =
   // Sony
   | 'sony-a7iv' | 'sony-a7riv' | 'sony-a7siii' | 'sony-a1' | 'sony-fx3' | 'sony-fx6'
   | 'sony-venice' | 'sony-venice-2' | 'sony-a9ii' | 'sony-zv-e1'
@@ -51,35 +51,35 @@ export type CameraModel =
   | 'blackmagic-ursa-mini-pro' | 'blackmagic-pocket-6k' | 'blackmagic-pocket-4k'
   | 'panavision-dxl2' | 'panavision-millennium-xl2';
 
-export type SensorFormat = 
+export type SensorFormat =
   | 'full-frame' | 'aps-c' | 'micro-four-thirds' | 'medium-format' | 'large-format'
   | 'super-35' | 'vista-vision' | 'imax' | '65mm' | '35mm-film' | '16mm-film' | '8mm-film';
 
-export type FilmFormat = 
+export type FilmFormat =
   | '35mm' | '120-medium-format' | '4x5-large-format' | '8x10-large-format'
   | '110-film' | 'instant-film' | 'super-8' | '16mm' | '65mm-imax';
 
 // --- Camera & Shot Types ---
-export type CameraAngle = 
-  | 'eye-level' | 'low-angle' | 'high-angle' | 'dutch-angle' | 'birds-eye' 
+export type CameraAngle =
+  | 'eye-level' | 'low-angle' | 'high-angle' | 'dutch-angle' | 'birds-eye'
   | 'worms-eye' | 'over-the-shoulder' | 'point-of-view' | 'aerial' | 'drone'
   | 'canted' | 'oblique' | 'hip-level' | 'knee-level' | 'ground-level';
 
-export type ShotType = 
+export type ShotType =
   | 'extreme-close-up' | 'close-up' | 'medium-close-up' | 'medium' | 'medium-wide'
   | 'wide' | 'extreme-wide' | 'establishing' | 'full-body' | 'portrait' | 'headshot';
 
-export type LensType = 
+export type LensType =
   | 'wide-angle' | 'ultra-wide' | 'standard' | 'telephoto' | 'macro' | 'fisheye'
   | '14mm' | '24mm' | '35mm' | '50mm' | '85mm' | '100mm' | '135mm' | '200mm' | '400mm'
   | '600mm' | '800mm' | 'tilt-shift' | 'anamorphic' | 'spherical' | 'prime' | 'zoom';
 
-export type LensBrand = 
+export type LensBrand =
   | 'zeiss' | 'leica' | 'canon' | 'nikon' | 'sony' | 'sigma' | 'tamron' | 'voigtlander'
   | 'fujifilm' | 'samyang' | 'rokinon' | 'tokina' | 'cooke' | 'arri' | 'panavision'
   | 'angenieux' | 'red' | 'atlas' | 'sirui';
 
-export type LensModel = 
+export type LensModel =
   // Zeiss
   | 'zeiss-otus-55' | 'zeiss-batis-85' | 'zeiss-milvus-35' | 'zeiss-supreme-prime'
   // Leica
@@ -96,50 +96,50 @@ export type LensModel =
   // Vintage
   | 'helios-44-2' | 'canon-fd-55' | 'minolta-rokkor-58' | 'pentax-takumar-50';
 
-export type FocusType = 
+export type FocusType =
   | 'shallow' | 'deep' | 'soft-focus' | 'tilt-shift' | 'rack-focus' | 'split-diopter'
   | 'zone-focus' | 'hyperfocal' | 'selective' | 'bokeh-heavy' | 'tack-sharp';
 
-export type BokehStyle = 
+export type BokehStyle =
   | 'smooth' | 'creamy' | 'swirly' | 'busy' | 'soap-bubble' | 'cat-eye' | 'oval-anamorphic';
 
-export type FilterType = 
+export type FilterType =
   | 'uv' | 'polarizer' | 'nd' | 'nd-graduated' | 'black-pro-mist' | 'white-pro-mist'
   | 'glimmer-glass' | 'classic-soft' | 'streak' | 'starburst' | 'diffusion'
   | 'infrared' | 'color-gel' | 'warming' | 'cooling' | 'vintage-look';
 
-export type CameraMovement = 
-  | 'static' | 'pan' | 'tilt' | 'dolly' | 'truck' | 'pedestal' | 'zoom' 
+export type CameraMovement =
+  | 'static' | 'pan' | 'tilt' | 'dolly' | 'truck' | 'pedestal' | 'zoom'
   | 'handheld' | 'steadicam' | 'crane' | 'drone' | 'tracking' | 'arc' | 'whip-pan'
   | 'roll' | 'boom' | 'jib' | 'cable-cam' | 'motion-control' | 'snorricam'
   | 'dutch-roll' | 'vertigo-effect' | 'crash-zoom' | 'slow-push' | 'slow-pull';
 
-export type CameraRig = 
+export type CameraRig =
   | 'tripod' | 'monopod' | 'gimbal' | 'steadicam' | 'easyrig' | 'shoulder-rig'
   | 'slider' | 'dolly' | 'jib' | 'crane' | 'technocrane' | 'russian-arm'
   | 'cable-cam' | 'drone' | 'fpv-drone' | 'motion-control' | 'handheld';
 
-export type GimbalModel = 
+export type GimbalModel =
   | 'dji-ronin-4d' | 'dji-ronin-rs3-pro' | 'dji-ronin-rs4' | 'moza-air-2'
   | 'zhiyun-crane-3s' | 'freefly-movi-pro' | 'tilta-gravity-g2x';
 
 // --- Lighting Types ---
-export type LightingType = 
+export type LightingType =
   | 'natural' | 'studio' | 'dramatic' | 'soft' | 'hard' | 'diffused'
   | 'key' | 'fill' | 'rim' | 'backlit' | 'silhouette' | 'rembrandt'
   | 'split' | 'butterfly' | 'loop' | 'broad' | 'short' | 'chiaroscuro'
   | 'high-key' | 'low-key' | 'three-point' | 'practical' | 'motivated';
 
-export type TimeOfDay = 
+export type TimeOfDay =
   | 'dawn' | 'sunrise' | 'golden-hour' | 'morning' | 'midday' | 'afternoon'
   | 'blue-hour' | 'sunset' | 'dusk' | 'twilight' | 'night' | 'midnight';
 
-export type WeatherLighting = 
-  | 'sunny' | 'cloudy' | 'overcast' | 'foggy' | 'misty' | 'rainy' 
+export type WeatherLighting =
+  | 'sunny' | 'cloudy' | 'overcast' | 'foggy' | 'misty' | 'rainy'
   | 'stormy' | 'snowy' | 'hazy';
 
 // --- Style Types ---
-export type ArtStyle = 
+export type ArtStyle =
   | 'photorealistic' | 'hyperrealistic' | 'cinematic' | 'documentary'
   | 'editorial' | 'fashion' | 'portrait' | 'landscape' | 'street'
   | 'fine-art' | 'conceptual' | 'surreal' | 'abstract' | 'minimalist'
@@ -149,9 +149,9 @@ export type ArtStyle =
   | 'comic-book' | 'illustration' | 'digital-art' | 'oil-painting' | 'watercolor'
   | 'sketch' | 'pencil-drawing' | 'charcoal' | 'pastel' | '3d-render';
 
-export type FilmStock = 
+export type FilmStock =
   // Kodak Color Negative
-  | 'kodak-portra-160' | 'kodak-portra-400' | 'kodak-portra-800' 
+  | 'kodak-portra-160' | 'kodak-portra-400' | 'kodak-portra-800'
   | 'kodak-ektar-100' | 'kodak-gold-200' | 'kodak-ultramax-400' | 'kodak-colorplus-200'
   // Kodak Black & White
   | 'kodak-tri-x-400' | 'kodak-tmax-100' | 'kodak-tmax-400' | 'kodak-tmax-3200'
@@ -178,46 +178,46 @@ export type FilmStock =
   | 'agfa-vista-400' | 'agfa-apx-100' | 'fomapan-100' | 'fomapan-400'
   | 'bergger-pancro-400' | 'jch-streetpan-400';
 
-export type AspectRatio = 
+export type AspectRatio =
   | '1:1' | '4:3' | '3:2' | '16:9' | '21:9' | '9:16' | '2:3' | '4:5' | '5:4';
 
 // --- Color & Mood ---
-export type ColorPalette = 
+export type ColorPalette =
   | 'warm' | 'cool' | 'neutral' | 'vibrant' | 'muted' | 'pastel' | 'neon'
   | 'monochrome' | 'sepia' | 'desaturated' | 'high-contrast' | 'low-contrast'
   | 'earthy' | 'oceanic' | 'forest' | 'sunset' | 'midnight' | 'golden';
 
-export type Mood = 
+export type Mood =
   | 'serene' | 'peaceful' | 'melancholic' | 'dramatic' | 'tense' | 'mysterious'
   | 'romantic' | 'nostalgic' | 'hopeful' | 'joyful' | 'energetic' | 'chaotic'
   | 'ethereal' | 'dark' | 'light' | 'whimsical' | 'eerie' | 'epic' | 'intimate';
 
 // --- Video Specific ---
-export type VideoTransition = 
+export type VideoTransition =
   | 'cut' | 'fade' | 'dissolve' | 'wipe' | 'morph' | 'match-cut' | 'jump-cut'
   | 'cross-dissolve' | 'iris' | 'push' | 'slide';
 
-export type VideoPacing = 
+export type VideoPacing =
   | 'slow' | 'medium' | 'fast' | 'variable' | 'building' | 'frenetic' | 'contemplative';
 
 // --- Audio/Music Specific ---
-export type MusicGenre = 
+export type MusicGenre =
   | 'pop' | 'rock' | 'jazz' | 'classical' | 'electronic' | 'hip-hop' | 'r&b'
   | 'country' | 'folk' | 'blues' | 'metal' | 'punk' | 'indie' | 'alternative'
   | 'ambient' | 'lo-fi' | 'synthwave' | 'orchestral' | 'cinematic' | 'world'
   | 'latin' | 'reggae' | 'soul' | 'funk' | 'disco' | 'house' | 'techno' | 'edm';
 
-export type Instrument = 
+export type Instrument =
   | 'piano' | 'guitar' | 'acoustic-guitar' | 'electric-guitar' | 'bass' | 'drums'
   | 'violin' | 'cello' | 'viola' | 'flute' | 'saxophone' | 'trumpet' | 'trombone'
   | 'synthesizer' | 'organ' | 'harp' | 'percussion' | 'strings' | 'brass' | 'woodwinds'
   | 'choir' | 'vocals' | 'beatbox' | 'turntables' | 'harmonica' | 'banjo' | 'ukulele';
 
-export type VocalStyle = 
+export type VocalStyle =
   | 'male' | 'female' | 'duet' | 'choir' | 'a-cappella' | 'spoken-word' | 'rap'
   | 'falsetto' | 'belting' | 'whisper' | 'growl' | 'melodic' | 'harmonized';
 
-export type Tempo = 
+export type Tempo =
   | 'largo' | 'adagio' | 'andante' | 'moderato' | 'allegro' | 'vivace' | 'presto'
   | number; // BPM
 
@@ -243,36 +243,36 @@ export interface ImageCamera {
   // Framing
   angle?: CameraAngle;
   shot?: ShotType;
-  
+
   // Camera Body
   brand?: CameraBrand;
   model?: CameraModel;
   sensor?: SensorFormat;
-  
+
   // Lens
   lens?: LensType;
   lensModel?: LensModel;
   lensBrand?: LensBrand;
   focalLength?: string;
-  
+
   // Focus & Depth
   focus?: FocusType;
   aperture?: string;
   bokeh?: BokehStyle;
   focusDistance?: string;
-  
+
   // Exposure
   iso?: number;
   shutterSpeed?: string;
   exposureCompensation?: string;
-  
+
   // Film/Digital
   filmStock?: FilmStock;
   filmFormat?: FilmFormat;
-  
+
   // Filters & Accessories
   filter?: FilterType | FilterType[];
-  
+
   // Camera Settings
   whiteBalance?: 'daylight' | 'cloudy' | 'tungsten' | 'fluorescent' | 'flash' | 'custom';
   colorProfile?: string;
@@ -371,7 +371,7 @@ export class ImagePromptBuilder {
   private _custom: string[] = [];
 
   // --- Subject Methods ---
-  
+
   subject(main: string | ImageSubject): this {
     if (typeof main === 'string') {
       this._subject = { ...(this._subject || {}), main };
@@ -876,9 +876,9 @@ export class ImagePromptBuilder {
   toMarkdown(): string {
     const built = this.build();
     const sections: string[] = ['# Image Prompt\n'];
-    
+
     sections.push('## Prompt\n```\n' + built.prompt + '\n```\n');
-    
+
     if (built.structure.subject) {
       sections.push('## Subject\n' + objectToMarkdownList(built.structure.subject));
     }
@@ -903,7 +903,7 @@ export class ImagePromptBuilder {
     if (built.structure.technical) {
       sections.push('## Technical\n' + objectToMarkdownList(built.structure.technical));
     }
-    
+
     return sections.join('\n');
   }
 
@@ -924,10 +924,10 @@ export class ImagePromptBuilder {
 function objectToYaml(obj: object, indent = 0): string {
   const spaces = '  '.repeat(indent);
   const lines: string[] = [];
-  
+
   for (const [key, value] of Object.entries(obj)) {
     if (value === undefined || value === null) continue;
-    
+
     if (Array.isArray(value)) {
       if (value.length === 0) continue;
       lines.push(`${spaces}${key}:`);
@@ -946,17 +946,17 @@ function objectToYaml(obj: object, indent = 0): string {
       lines.push(`${spaces}${key}: ${value}`);
     }
   }
-  
+
   return lines.join('\n');
 }
 
 function objectToMarkdownList(obj: object, indent = 0): string {
   const spaces = '  '.repeat(indent);
   const lines: string[] = [];
-  
+
   for (const [key, value] of Object.entries(obj)) {
     if (value === undefined || value === null) continue;
-    
+
     if (Array.isArray(value)) {
       lines.push(`${spaces}- **${key}:** ${value.join(', ')}`);
     } else if (typeof value === 'object') {
@@ -966,7 +966,7 @@ function objectToMarkdownList(obj: object, indent = 0): string {
       lines.push(`${spaces}- **${key}:** ${value}`);
     }
   }
-  
+
   return lines.join('\n');
 }
 

--- a/packages/prompts.chat/src/index.ts
+++ b/packages/prompts.chat/src/index.ts
@@ -1,28 +1,28 @@
 /**
  * prompts.chat - Developer toolkit for AI prompts
- * 
+ *
  * @example
  * ```ts
  * import { variables, similarity, builder, quality } from 'prompts.chat';
- * 
+ *
  * // Detect and normalize variables
  * const vars = variables.detect("Hello {{name}}, you are [ROLE]");
  * const normalized = variables.normalize("Hello {{name}}");
  * // → "Hello ${name}"
- * 
+ *
  * // Check similarity
  * const score = similarity.calculate(prompt1, prompt2);
  * const isDupe = similarity.isDuplicate(prompt1, prompt2);
- * 
+ *
  * // Build structured prompts
  * const prompt = builder()
  *   .role("Senior Developer")
  *   .task("Review code")
  *   .build();
- * 
+ *
  * // Check quality locally
  * const result = quality.check("Act as a developer...");
- * 
+ *
  * ```
  */
 
@@ -33,9 +33,9 @@ export * as quality from './quality';
 export * as parser from './parser';
 
 // Builder exports (special handling for fluent API)
-export { 
-  builder, 
-  fromPrompt, 
+export {
+  builder,
+  fromPrompt,
   templates,
   PromptBuilder,
   video,
@@ -56,9 +56,9 @@ export {
 } from './builder';
 
 // Variable utilities
-export { 
-  detectVariables, 
-  convertToSupportedFormat, 
+export {
+  detectVariables,
+  convertToSupportedFormat,
   convertAllVariables,
   extractVariables,
   compile,
@@ -69,9 +69,9 @@ export {
 } from './variables';
 
 // Similarity utilities
-export { 
-  calculateSimilarity, 
-  isSimilarContent, 
+export {
+  calculateSimilarity,
+  isSimilarContent,
   normalizeContent,
   getContentFingerprint,
   findDuplicates,


### PR DESCRIPTION
Small scoped patch based on the reported behavior.

Related to #1129.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Normalizes source formatting and whitespace across `prompts.chat` builders, documentation generation, and package exports.

- Reformats prompt builder implementations and serializers without changing behavior.
- Normalizes exported type and re-export formatting.
- Cleans up documentation generator spacing and generated output formatting.
- No changes to public APIs or prompt generation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->