### PR TITLE
Add validation and caps for public /api/prompts pagination

### DIFF
--- a/src/__tests__/api/prompts.test.ts
+++ b/src/__tests__/api/prompts.test.ts
@@ -87,6 +87,36 @@ describe("GET /api/prompts", () => {
     expect(data.perPage).toBe(24);
   });
 
+  it("should fall back to defaults when pagination parameters are malformed", async () => {
+    vi.mocked(db.prompt.findMany).mockResolvedValue([]);
+    vi.mocked(db.prompt.count).mockResolvedValue(0);
+
+    const request = new Request(
+      "http://localhost:3000/api/prompts?page=not-a-number&perPage=bad-value"
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.page).toBe(1);
+    expect(data.perPage).toBe(24);
+  });
+
+  it("should clamp pagination parameters to configured maximums", async () => {
+    vi.mocked(db.prompt.findMany).mockResolvedValue([]);
+    vi.mocked(db.prompt.count).mockResolvedValue(0);
+
+    const request = new Request(
+      "http://localhost:3000/api/prompts?page=20000&perPage=999"
+    );
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.page).toBe(10000);
+    expect(data.perPage).toBe(100);
+  });
+
   it("should filter by type", async () => {
     vi.mocked(db.prompt.findMany).mockResolvedValue([]);
     vi.mocked(db.prompt.count).mockResolvedValue(0);

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -306,11 +306,32 @@ export async function POST(request: Request) {
 }
 
 // List prompts (for API access)
+const MAX_API_PER_PAGE = 100;
+const DEFAULT_API_PER_PAGE = 24;
+const MAX_API_PAGE = 10000;
+const DEFAULT_API_PAGE = 1;
+
+const parsePositiveInt = (
+  value: string | null,
+  defaultValue: number,
+  maxValue: number
+): number => {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+  return Math.min(parsed, maxValue);
+};
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const page = parseInt(searchParams.get("page") || "1");
-    const perPage = parseInt(searchParams.get("perPage") || "24");
+    const page = parsePositiveInt(searchParams.get("page"), DEFAULT_API_PAGE, MAX_API_PAGE);
+    const perPage = parsePositiveInt(
+      searchParams.get("perPage"),
+      DEFAULT_API_PER_PAGE,
+      MAX_API_PER_PAGE
+    );
     const type = searchParams.get("type");
     const categoryId = searchParams.get("category");
     const tag = searchParams.get("tag");

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -311,27 +311,28 @@ const DEFAULT_API_PER_PAGE = 24;
 const MAX_API_PAGE = 10000;
 const DEFAULT_API_PAGE = 1;
 
-const parsePositiveInt = (
-  value: string | null,
-  defaultValue: number,
-  maxValue: number
-): number => {
-  const parsed = Number.parseInt(value ?? "", 10);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    return defaultValue;
-  }
-  return Math.min(parsed, maxValue);
-};
+const paginationQuerySchema = z.object({
+  page: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .transform((value) => Math.min(value, MAX_API_PAGE))
+    .catch(DEFAULT_API_PAGE),
+  perPage: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .transform((value) => Math.min(value, MAX_API_PER_PAGE))
+    .catch(DEFAULT_API_PER_PAGE),
+});
 
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const page = parsePositiveInt(searchParams.get("page"), DEFAULT_API_PAGE, MAX_API_PAGE);
-    const perPage = parsePositiveInt(
-      searchParams.get("perPage"),
-      DEFAULT_API_PER_PAGE,
-      MAX_API_PER_PAGE
-    );
+    const { page, perPage } = paginationQuerySchema.parse({
+      page: searchParams.get("page"),
+      perPage: searchParams.get("perPage"),
+    });
     const type = searchParams.get("type");
     const categoryId = searchParams.get("category");
     const tag = searchParams.get("tag");


### PR DESCRIPTION
Supersedes #1221 after restoring the source branch. Adds bounded, validated pagination for the public prompts API with focused tests for malformed and oversized query values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds validated, bounded pagination to the public `/api/prompts` endpoint.

- Applies defaults for malformed `page` and `perPage` values.
- Clamps values to maximums of page `10000` and `perPage` `100`.
- Adds focused tests covering invalid and oversized parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->