### PR TITLE
Add MiniMax-M3 and MiniMax-M2.7 to model registry

### DIFF
--- a/src/__tests__/lib/works-best-with.test.ts
+++ b/src/__tests__/lib/works-best-with.test.ts
@@ -30,6 +30,11 @@ describe("getModelInfo", () => {
     expect(getModelInfo("sora 2")).toEqual({ name: "Sora 2", provider: "OpenAI" });
     expect(getModelInfo("runway-gen4")).toEqual({ name: "Runway Gen-4", provider: "Runway" });
   });
+
+  it("returns correct info for MiniMax models", () => {
+    expect(getModelInfo("minimax-m3")).toEqual({ name: "MiniMax-M3", provider: "MiniMax" });
+    expect(getModelInfo("minimax-m2-7")).toEqual({ name: "MiniMax-M2.7", provider: "MiniMax" });
+  });
 });
 
 describe("isValidModelSlug", () => {
@@ -61,6 +66,7 @@ describe("getModelsByProvider", () => {
     expect(grouped).toHaveProperty("Anthropic");
     expect(grouped).toHaveProperty("Google");
     expect(grouped).toHaveProperty("xAI");
+    expect(grouped).toHaveProperty("MiniMax");
   });
 
   it("includes all OpenAI models under OpenAI provider", () => {

--- a/src/lib/works-best-with.ts
+++ b/src/lib/works-best-with.ts
@@ -32,6 +32,10 @@ export const AI_MODELS = {
   "grok-4": { name: "Grok 4", provider: "xAI" },
   "grok-3": { name: "Grok 3", provider: "xAI" },
 
+  // MiniMax
+  "minimax-m3": { name: "MiniMax-M3", provider: "MiniMax" },
+  "minimax-m2-7": { name: "MiniMax-M2.7", provider: "MiniMax" },
+
   // Image Generation
   "nano-banana": { name: "Nano Banana", provider: "Google" },
   "nano-banana-pro": { name: "Nano Banana Pro", provider: "Google" },


### PR DESCRIPTION
## Summary
- Add MiniMax-M3 and MiniMax-M2.7 to the model registry.
- Cover model lookup and provider grouping in tests.

## Testing
- `npm test -- src/__tests__/lib/works-best-with.test.ts`
- `npm run lint -- src/lib/works-best-with.ts src/__tests__/lib/works-best-with.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds MiniMax-M3 and MiniMax-M2.7 to the model registry, including valid slugs and MiniMax provider grouping. Extends tests to verify model lookup and provider inclusion.

Tests:
- `npm test -- src/__tests__/lib/works-best-with.test.ts`
- `npm run lint -- src/lib/works-best-with.ts src/__tests__/lib/works-best-with.test.ts`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->