### PR TITLE
fix(mcp): require SDK >=1.26.0 — one MCP request 500s the entire site on self-hosted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
-        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "@monaco-editor/react": "^4.7.0",
         "@next/mdx": "^16.1.1",
         "@prisma/client": "^6.19.0",
@@ -2253,12 +2253,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.7",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
-      "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2972,12 +2972,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
-      "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.7",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -2985,14 +2985,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -9858,21 +9859,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
-      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -10471,9 +10485,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12473,10 +12487,14 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -13348,11 +13366,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.1.tgz",
-      "integrity": "sha512-KsFcH0xxHes0J4zaQgWbYwmz3UPOOskdqZmItstUG93+Wk1ePBLkLGwbP9zlmh1BFUiL8Qp+Xfu9P7feJWpGNg==",
+      "version": "4.12.33",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
+      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -13436,9 +13453,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
-      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -13565,10 +13582,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "dev": true,
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -14822,7 +14838,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
       "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.4",
@@ -15203,12 +15219,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -16328,17 +16348,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -17319,9 +17328,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -17847,12 +17856,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -17899,12 +17909,16 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -18885,14 +18899,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -18904,13 +18918,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -20008,17 +20022,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -21740,12 +21771,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz",
-      "integrity": "sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@modelcontextprotocol/sdk": "^1.24.3",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@monaco-editor/react": "^4.7.0",
     "@next/mdx": "^16.1.1",
     "@prisma/client": "^6.19.0",

--- a/src/__tests__/api/mcp-global-response.test.ts
+++ b/src/__tests__/api/mcp-global-response.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression test: a single POST /api/mcp must not take the whole site down.
+ *
+ * `@hono/node-server`'s `getRequestListener()` permanently replaces
+ * `globalThis.Request` / `globalThis.Response` unless it is passed
+ * `overrideGlobalObjects: false`:
+ *
+ *     if (options.overrideGlobalObjects !== false && global.Request !== Request) {
+ *       Object.defineProperty(global, "Request", { value: Request })
+ *       Object.defineProperty(global, "Response", { value: Response })
+ *     }
+ *
+ * The MCP SDK's Node `StreamableHTTPServerTransport` calls it with no options —
+ * both in its constructor and in every `handleRequest`. On a long-lived process
+ * (`next start`, Docker, Cloud Run, Fly, a VPS) the first MCP request therefore
+ * swaps the global `Response` for the lifetime of the process.
+ *
+ * `NextResponse` subclasses the *original* `Response` at module load, so
+ * afterwards `response instanceof Response` is false in
+ * `next/dist/esm/server/web/adapter.js` and EVERY request matching the
+ * `src/proxy.ts` matcher dies with
+ * `TypeError: Expected an instance of Response to be returned`.
+ *
+ * Serverless deployments are unaffected: middleware runs in a separate isolate
+ * there, so the Node-global mutation cannot cross realms.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    user: { findUnique: vi.fn() },
+    prompt: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+    tag: { findUnique: vi.fn(), create: vi.fn() },
+    category: { findMany: vi.fn(), findUnique: vi.fn() },
+    $queryRaw: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  mcpGeneralLimiter: { check: vi.fn().mockReturnValue({ allowed: true }) },
+  mcpToolCallLimiter: { check: vi.fn().mockReturnValue({ allowed: true }) },
+  mcpWriteToolLimiter: { check: vi.fn().mockReturnValue({ allowed: true }) },
+  mcpAiToolLimiter: { check: vi.fn().mockReturnValue({ allowed: true }) },
+}));
+
+vi.mock("@/../prompts.config", () => ({
+  default: { features: { mcp: true } },
+}));
+
+vi.mock("@/lib/api-key", () => ({
+  isValidApiKeyFormat: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/lib/skill-files", () => ({
+  parseSkillFiles: vi.fn(),
+  serializeSkillFiles: vi.fn(),
+  sanitizeFilename: vi.fn(),
+  DEFAULT_SKILL_FILE: "SKILL.md",
+}));
+
+/** Minimal NextApiResponse shims over a real Node ServerResponse. */
+function decorate(res: http.ServerResponse) {
+  const r = res as http.ServerResponse & Record<string, unknown>;
+  r.status = (code: number) => {
+    res.statusCode = code;
+    return r;
+  };
+  r.json = (body: unknown) => {
+    if (!res.headersSent) res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(body));
+    return r;
+  };
+  return r;
+}
+
+describe("/api/mcp must not leak @hono/node-server's global Request/Response swap", () => {
+  let server: http.Server;
+  let url: string;
+
+  beforeEach(async () => {
+    const { default: handler } = await import("@/pages/api/mcp");
+    server = http.createServer((req, res) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      void handler(req as any, decorate(res) as any);
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    url = `http://127.0.0.1:${(server.address() as AddressInfo).port}/api/mcp`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("leaves globalThis.Response identical after a real MCP initialize request", async () => {
+    const OriginalResponse = globalThis.Response;
+    const OriginalRequest = globalThis.Request;
+
+    // Subclass exactly the way NextResponse does, before any MCP traffic.
+    class NextResponseLike extends Response {}
+    const sentinel = new NextResponseLike(null, { status: 204 });
+    expect(sentinel instanceof globalThis.Response).toBe(true);
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "regression-test", version: "1.0.0" },
+        },
+      }),
+    });
+    await res.text(); // drain so the request fully completes
+
+    expect(globalThis.Response).toBe(OriginalResponse);
+    expect(globalThis.Request).toBe(OriginalRequest);
+
+    // The actual production symptom: Next's middleware adapter runs this check
+    // on every request, and threw `Expected an instance of Response to be
+    // returned` site-wide once the global had been swapped.
+    expect(sentinel instanceof globalThis.Response).toBe(true);
+  });
+});

--- a/src/pages/api/mcp.ts
+++ b/src/pages/api/mcp.ts
@@ -1359,28 +1359,48 @@ class PayloadTooLargeError extends Error {
   }
 }
 
+class ClientDisconnectedError extends Error {
+  constructor() {
+    super("Client disconnected before the request body was received");
+    this.name = "ClientDisconnectedError";
+  }
+}
+
 async function parseBody(req: NextApiRequest): Promise<unknown> {
   const MAX_BODY_SIZE = 1024 * 1024; // 1MB
   return new Promise((resolve, reject) => {
     let body = "";
     let bytesReceived = 0;
+    let settled = false;
+    const settle = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      action();
+    };
+
     req.on("data", (chunk: Buffer | string) => {
       bytesReceived += Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(chunk);
       body += chunk;
       if (bytesReceived > MAX_BODY_SIZE) {
         req.destroy();
-        reject(new PayloadTooLargeError());
+        settle(() => reject(new PayloadTooLargeError()));
         return;
       }
     });
     req.on("end", () => {
-      try {
-        resolve(JSON.parse(body));
-      } catch {
-        resolve(body);
-      }
+      settle(() => {
+        try {
+          resolve(JSON.parse(body));
+        } catch {
+          resolve(body);
+        }
+      });
     });
-    req.on("error", reject);
+    req.on("error", (err) => settle(() => reject(err)));
+    // A client that disconnects mid-upload emits `close` without `end` or `error`.
+    // Without this the promise never settles and the McpServer/transport it is
+    // holding are retained for the lifetime of the process.
+    req.on("close", () => settle(() => reject(new ClientDisconnectedError())));
   });
 }
 
@@ -1443,10 +1463,30 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const server = createServer(serverOptions);
 
+  let toreDown = false;
+  const teardown = (transport?: StreamableHTTPServerTransport) => {
+    if (toreDown) return;
+    toreDown = true;
+    // Both are async; a failure to close must never reject into the request path.
+    void Promise.resolve()
+      .then(() => transport?.close())
+      .catch(() => {});
+    void Promise.resolve()
+      .then(() => server.close())
+      .catch(() => {});
+  };
+
+  let transport: StreamableHTTPServerTransport | undefined;
+
   try {
-    const transport = new StreamableHTTPServerTransport({
+    transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     });
+
+    // Registered BEFORE dispatch: previously this was attached after awaiting
+    // handleRequest, by which point the response may already have closed, so the
+    // listener never fired and every MCP request leaked an McpServer + transport.
+    res.once("close", () => teardown(transport));
 
     await server.connect(transport);
 
@@ -1502,12 +1542,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     await transport.handleRequest(req, res, body);
-
-    res.on("close", () => {
-      transport.close();
-      server.close();
-    });
   } catch (error) {
+    if (error instanceof ClientDisconnectedError) {
+      // Routine: the peer went away mid-upload. Nothing to log and nothing to
+      // send — the `finally` below still releases the transport and server.
+      return;
+    }
     console.error("MCP error:", error);
     if (!res.headersSent) {
       if (error instanceof PayloadTooLargeError) {
@@ -1524,5 +1564,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         });
       }
     }
+  } finally {
+    // Backstop: covers the aborted/errored paths, the early `return`s above
+    // (rate-limit 429s previously leaked unconditionally), and the case where
+    // `close` fired before the listener was attached. Idempotent, and safe here
+    // because handleRequest has already fully written the response.
+    teardown(transport);
   }
 }


### PR DESCRIPTION
On any **long-lived Node deployment** — `next start`, Docker (`ghcr.io/f/prompts.chat`), Cloud Run, Fly, a VPS — a single `POST /api/mcp` permanently breaks **every route**. After one request, `/`, `/login` and `/api/health` all return 500:

```
TypeError: Expected an instance of Response to be returned
```

Only a process restart clears it. **Vercel and other serverless hosts are unaffected**, which is why this is invisible on the hosted site.

No credentials are needed to trigger it — the handler builds the transport before any auth check.

## Cause

`@hono/node-server` replaces the Node globals inside `getRequestListener()` unless passed `overrideGlobalObjects: false`:

```js
if (options.overrideGlobalObjects !== false && global.Request !== Request) {
  Object.defineProperty(global, "Request",  { value: Request })
  Object.defineProperty(global, "Response", { value: Response })
}
```

`@modelcontextprotocol/sdk` **1.25.x** calls it with no options — from the transport constructor *and* from every `handleRequest`. `NextResponse` subclasses the *original* `Response` captured at module load, so once the global is swapped, `src/proxy.ts` fails Next's check in `next/dist/esm/server/web/adapter.js`:

```js
if (response && !(response instanceof Response)) {
  throw new TypeError('Expected an instance of Response to be returned')
}
```

…for every request matching the proxy matcher — i.e. the entire site. Serverless is immune because middleware runs in a separate isolate, so a Node-global mutation cannot cross realms.

## Why this happened with no code change

| SDK version | `overrideGlobalObjects: false` |
|---|---|
| 1.24.3 | n/a — no hono dependency at all |
| 1.25.0 – 1.25.2 | ❌ **broken** |
| 1.25.3 | ✅ fixed |
| 1.26.0 + | ✅ fixed ([#1369](https://github.com/modelcontextprotocol/typescript-sdk/issues/1369)) |

> **Correction (table above):** an earlier revision of this description jumped straight from `1.25.2` to `1.26.0+`, implying 1.25.3 was still affected. It is not — **1.25.3 also passes `overrideGlobalObjects: false`**. Verified by unpacking each published tarball. `^1.26.0` remains a safe floor, so the proposed fix is unchanged; the table was simply incomplete.

`package.json` declared `^1.24.3` — a version with no hono dependency — so the caret range silently resolved into the broken 1.25.x window, and the lockfile pinned it at 1.25.1.

Worth noting: **hono itself is not fixed.** `@hono/node-server@2.0.12` still contains the `Object.defineProperty(global, "Response", …)` call; the referenced hono PR only removed the `fetch` override. So raising the SDK floor is the actual fix, not bumping hono.

## The fix

Raise the floor to `^1.26.0` and refresh the lockfile (resolves to 1.30.0).

Verified: with only the SDK bumped and **no application code changes**, the added regression test passes; on 1.25.1 it fails.

I checked [#1994](https://github.com/modelcontextprotocol/typescript-sdk/issues/1994) (stateless transport regression) before recommending the bump — it only affects *reused* transport instances, and this handler constructs a fresh transport per request, so it does not apply.

## Two other leaks fixed in the same handler

Both are independent of SDK version and present today:

1. **`res.on("close")` was registered *after* `await transport.handleRequest(...)`**, by which point the response may already have closed — so the listener often never fired and the `McpServer` + transport were never released. Now registered before dispatch, with an idempotent `teardown()` in `finally` that also covers the early `return`s (rate-limit 429s previously leaked unconditionally).

2. **`parseBody` could never settle.** A client disconnecting mid-upload emits `close` without `end`/`error`, so the promise stayed pending and pinned the server/transport for the life of the process. It now settles once, on whichever of `end`/`error`/`close` arrives first.

## Test

`src/__tests__/api/mcp-global-response.test.ts` drives a real `initialize` through the handler over a real socket and asserts `globalThis.Response` is unchanged — guarding against the dependency drifting back into the broken window. 307 API tests pass, lint clean.

Found while migrating a self-hosted instance from Vercel to Cloud Run, where it caused a full outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve the original global `Request` and `Response` objects around MCP transport construction and request handling.
- Add idempotent MCP teardown and register the close listener before dispatch.
- Ensure request-body parsing settles when uploads complete, fail, or disconnect.
- Update `@modelcontextprotocol/sdk` to `^1.26.0`.
- Add a regression test that sends a real MCP `initialize` request and verifies that global constructors remain unchanged.

## Testing

- Added `src/__tests__/api/mcp-global-response.test.ts`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
