### PR TITLE
Add sample Facebook Messenger webhook server and README

### DIFF
--- a/webhook-server/README.md
+++ b/webhook-server/README.md
@@ -1,0 +1,33 @@
+Setup and testing for the sample Facebook Messenger webhook
+
+1) Install and run the server
+   cd webhook-server
+   npm init -y
+   npm install express body-parser
+n   # set a verify token and (optionally) PAGE_ACCESS_TOKEN
+   set VERIFY_TOKEN=your_verify_token_here   # Windows PowerShell: $env:VERIFY_TOKEN = "..."
+   set PAGE_ACCESS_TOKEN=your_page_access_token_here
+
+   node server.js
+
+2) Expose locally with ngrok (HTTPS required by Facebook)
+   ngrok http 3000
+   # copy the https URL (e.g. https://abcd1234.ngrok.io)
+
+3) Configure the App (developers.facebook.com)
+   - My Apps → Create App (choose Business or appropriate type)
+   - App Dashboard → Add Product → Messenger → Set up
+   - Under Webhooks: Callback URL = https://<NGROK_HOST>/webhook
+                      Verify token = the same VERIFY_TOKEN you set
+   - Subscribe to fields: messages, messaging_postbacks, messaging_optins, message_deliveries
+
+4) Subscribe your Page to the app
+   Using Graph API (replace PAGE_ID and PAGE_ACCESS_TOKEN):
+   curl -X POST "https://graph.facebook.com/v17.0/PAGE_ID/subscribed_apps?access_token=PAGE_ACCESS_TOKEN"
+
+5) Notes
+   - In development mode the app only receives events for Pages where the app admin/tester is added.
+   - To receive events from real users you must submit for App Review and switch the app live.
+   - Implement Send API calls using the PAGE_ACCESS_TOKEN to reply to users.
+
+If you want, update the server to send replies (I can add Send API example and a .env + npm scripts).

--- a/webhook-server/server.js
+++ b/webhook-server/server.js
@@ -1,0 +1,46 @@
+// Simple Facebook Messenger webhook server (Express)
+const express = require('express');
+const bodyParser = require('body-parser');
+const app = express();
+app.use(bodyParser.json());
+
+const VERIFY_TOKEN = process.env.VERIFY_TOKEN || 'verify_token_here';
+
+// Webhook verification handshake
+app.get('/webhook', (req, res) => {
+  const mode = req.query['hub.mode'];
+  const token = req.query['hub.verify_token'];
+  const challenge = req.query['hub.challenge'];
+
+  if (mode === 'subscribe' && token === VERIFY_TOKEN) {
+    return res.status(200).send(challenge);
+  }
+  return res.sendStatus(403);
+});
+
+// Webhook event receiver
+app.post('/webhook', (req, res) => {
+  console.log('Webhook event:', JSON.stringify(req.body, null, 2));
+n  // Basic handling: iterate entries and messaging events
+  if (req.body.object === 'page') {
+    req.body.entry.forEach(entry => {
+      const events = entry.messaging || [];
+      events.forEach(event => {
+        if (event.message) {
+          const senderId = event.sender.id;
+          const text = event.message.text;
+          console.log(`Message from ${senderId}: ${text}`);
+          // TODO: reply using Send API with PAGE_ACCESS_TOKEN
+        } else if (event.postback) {
+          console.log('Postback:', event.postback);
+        }
+      });
+    });
+  }
+
+  // Must respond 200 quickly
+  res.sendStatus(200);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Webhook server listening on port ${PORT}`));


### PR DESCRIPTION
## Description

Adds a minimal Node/Express webhook and README to help developers test and integrate with the Facebook Messenger Send API and webhooks. This provides a local development example (ngrok instructions) and a basic webhook handler that logs incoming messaging events.

## Type of Change

- [ ] Bug fix
- [ ] Documentation update
- [x] Other (please describe): Add sample webhook server and developer guide

---

## ⚠️ Want to Add a New Prompt?

**Please don't edit `prompts.csv` directly!**

N/A

---

## Additional Notes

Files added:
- webhook-server/server.js — small Express webhook with verification and event logging
- webhook-server/README.md — setup, ngrok, and Messenger app configuration steps

Testing:
1. Set VERIFY_TOKEN and PAGE_ACCESS_TOKEN env vars
2. Run server and expose via ngrok
3. Configure App Dashboard webhooks to point to https://<ngrok>/webhook and use the same verify token

Notes:
- In development the app only receives events for Pages where the app admin/tester is added. App Review and switching live are required for public usage.
- No breaking changes to the app. Please review the README for verification and subscribe steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a minimal Express server for Facebook Messenger webhooks.
- Added webhook verification and logging for messaging and postback events.
- Added setup instructions for environment variables, ngrok, Facebook App configuration, and Page subscription.
- Documented development-mode restrictions and App Review requirements.

## Testing

- No automated tests were added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->