### PR TITLE
fix: prevent tag dropdown closing before click registers

### DIFF
--- a/src/components/prompts/prompt-form.tsx
+++ b/src/components/prompts/prompt-form.tsx
@@ -913,6 +913,10 @@ export function PromptForm({ categories, tags, initialData, initialContributors 
                           <button
                             key={tag.id}
                             type="button"
+                            onMouseDown={(e) => {
+                              // Prevent input blur from firing before click registers
+                              e.preventDefault();
+                            }}
                             onClick={() => {
                               toggleTag(tag.id);
                               setTagSearch("");


### PR DESCRIPTION
## Description

Fix a race condition in Firefox-based browsers (Zen Browser) where the tag dropdown closes before a click on a suggestion registers, making it impossible to add tags manually.

Added `onMouseDown` with `e.preventDefault()` to tag dropdown buttons to prevent the input's `onBlur` from firing before the `onClick` event registers.

## Type of Change

- [x] Bug fix

## Additional Notes

Root cause: `onBlur` with `setTimeout(150ms)` is not sufficient to prevent the dropdown from closing before click in Firefox-based browsers. The fix uses `onMouseDown` + `e.preventDefault()` — a standard pattern that prevents focus loss when clicking dropdown items.

Fixes #1172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes manual tag selection in Firefox and Zen Browser.

Tag suggestion buttons now prevent input blur on `onMouseDown`, so the dropdown remains open until the tag `onClick` handler runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->