### PR TITLE
feat(media): add MiniMax music generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,17 @@ CRON_SECRET="your-secret-key-here"
 # FAL_VIDEO_MODELS="fal-ai/veo3,fal-ai/kling-video/v2/master/text-to-video"  # Comma-separated list of video models
 # FAL_IMAGE_MODELS="fal-ai/flux-pro/v1.1-ultra,fal-ai/flux/dev"  # Comma-separated list of image models
 
+# Media Generation - MiniMax music (optional)
+# MINIMAX_API_KEY=your_minimax_api_key
+# MINIMAX_REGION=global_en  # global_en or cn_zh
+# MINIMAX_AUDIO_FORMAT=mp3  # mp3, wav, or pcm
+# MINIMAX_SAMPLE_RATE=44100
+# MINIMAX_BITRATE=256000
+# MINIMAX_LYRICS=
+# MINIMAX_LYRICS_OPTIMIZER=false
+# MINIMAX_IS_INSTRUMENTAL=true
+# MINIMAX_AIGC_WATERMARK=false  # China endpoint only
+
 # SENTRY_AUTH_TOKEN=sentry-auth-token
 
 # GOOGLE_ADSENSE_ACCOUNT=ca-pub-xxxxxxxxxxxxxxxx
@@ -113,4 +124,3 @@ CRON_SECRET="your-secret-key-here"
 # AUTH_OAUTH_JWKS_URL="https://sso.example.com/jwks"
 # AUTH_OAUTH_TOKEN_AUTH_METHOD="client_secret_basic" # Allowed values: "client_secret_basic", "client_secret_post", "none"
 # AUTH_OAUTH_ENABLE_PKCE="true" # PKCE is enabled by default. Set to "false" to disable.
-

--- a/src/__tests__/lib/plugins/media-generators/minimax.test.ts
+++ b/src/__tests__/lib/plugins/media-generators/minimax.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getMediaGeneratorPlugin } from "@/lib/plugins/media-generators";
+import {
+  generateMiniMaxMusic,
+  MINIMAX_MUSIC_CONFIG,
+  minimaxGeneratorPlugin,
+  parseMiniMaxMusicResponse,
+} from "@/lib/plugins/media-generators/minimax";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("MiniMax music generator", () => {
+  it("publishes the current music models and formats", () => {
+    expect(getMediaGeneratorPlugin("minimax")).toBe(minimaxGeneratorPlugin);
+    expect(MINIMAX_MUSIC_CONFIG).toMatchObject({
+      models: ["music-3.0", "music-2.6", "music-3.0-free", "music-2.6-free"],
+      outputFormats: ["url", "hex"],
+      streamOutputFormats: ["hex"],
+      audioFormats: ["mp3", "wav", "pcm"],
+      urlTtlHours: 24,
+    });
+  });
+
+  it("sends the CN request fields and parses completed audio", async () => {
+    vi.stubEnv("MINIMAX_API_KEY", "test-key");
+    vi.stubEnv("MINIMAX_REGION", "cn_zh");
+    vi.stubEnv("MINIMAX_AUDIO_FORMAT", "wav");
+    vi.stubEnv("MINIMAX_SAMPLE_RATE", "44100");
+    vi.stubEnv("MINIMAX_BITRATE", "256000");
+    vi.stubEnv("MINIMAX_LYRICS", "[Verse]\nA bright new day");
+    vi.stubEnv("MINIMAX_LYRICS_OPTIMIZER", "true");
+    vi.stubEnv("MINIMAX_IS_INSTRUMENTAL", "false");
+    vi.stubEnv("MINIMAX_AIGC_WATERMARK", "true");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: { status: 2, audio: "https://example.test/music.wav" },
+          base_resp: { status_code: 0 },
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(
+      generateMiniMaxMusic({
+        prompt: "A bright instrumental theme",
+        model: "music-3.0",
+        type: "audio",
+      }),
+    ).resolves.toBe("https://example.test/music.wav");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.minimaxi.com/v1/music_generation",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-key",
+          "Content-Type": "application/json",
+        },
+      }),
+    );
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body).toEqual({
+      model: "music-3.0",
+      prompt: "A bright instrumental theme",
+      stream: false,
+      output_format: "url",
+      audio_setting: { format: "wav", sample_rate: 44100, bitrate: 256000 },
+      lyrics: "[Verse]\nA bright new day",
+      lyrics_optimizer: true,
+      is_instrumental: false,
+      aigc_watermark: true,
+    });
+  });
+
+  it("uses the global endpoint and exposes audio models when configured", () => {
+    vi.stubEnv("MINIMAX_API_KEY", "test-key");
+    expect(minimaxGeneratorPlugin.getModels()).toHaveLength(4);
+    expect(MINIMAX_MUSIC_CONFIG.endpoints.global_en).toBe(
+      "https://api.minimax.io/v1/music_generation",
+    );
+  });
+
+  it("rejects models outside the music generation registry", async () => {
+    vi.stubEnv("MINIMAX_API_KEY", "test-key");
+
+    await expect(
+      generateMiniMaxMusic({
+        prompt: "A bright instrumental theme",
+        model: "unsupported-model",
+        type: "audio",
+      }),
+    ).rejects.toThrow("Unsupported MiniMax music generation model");
+  });
+
+  it("rejects unsuccessful responses", () => {
+    expect(() =>
+      parseMiniMaxMusicResponse({
+        data: { status: 1 },
+        base_resp: { status_code: 1004, status_msg: "Authentication failed" },
+      }),
+    ).toThrow("Authentication failed");
+  });
+
+  it("parses hex audio responses into playable data URLs", () => {
+    expect(
+      parseMiniMaxMusicResponse(
+        {
+          data: { status: 2, audio: "67656e6572617465642d617564696f" },
+          base_resp: { status_code: 0 },
+        },
+        "hex",
+        "wav",
+      ),
+    ).toBe("data:audio/wav;base64,Z2VuZXJhdGVkLWF1ZGlv");
+  });
+
+  it("rejects malformed hex audio responses", () => {
+    expect(() =>
+      parseMiniMaxMusicResponse(
+        {
+          data: { status: 2, audio: "not-hex" },
+          base_resp: { status_code: 0 },
+        },
+        "hex",
+      ),
+    ).toThrow("invalid hex audio");
+  });
+
+  it("rejects unsafe audio output URLs", () => {
+    expect(() =>
+      parseMiniMaxMusicResponse({
+        data: { status: 2, audio: "javascript:alert(1)" },
+        base_resp: { status_code: 0 },
+      }),
+    ).toThrow("insecure audio URL");
+  });
+});

--- a/src/lib/plugins/media-generators/index.ts
+++ b/src/lib/plugins/media-generators/index.ts
@@ -10,6 +10,7 @@
 
 import { wiroGeneratorPlugin } from "./wiro";
 import { falGeneratorPlugin } from "./fal";
+import { minimaxGeneratorPlugin } from "./minimax";
 import type { MediaGeneratorPlugin, MediaGeneratorModel, MediaType, WebSocketHandler } from "./types";
 
 export * from "./types";
@@ -20,6 +21,7 @@ export * from "./types";
 const plugins: MediaGeneratorPlugin[] = [
   wiroGeneratorPlugin,
   falGeneratorPlugin,
+  minimaxGeneratorPlugin,
   // Add new plugins here:
   // myNewPlugin,
 ];

--- a/src/lib/plugins/media-generators/minimax.ts
+++ b/src/lib/plugins/media-generators/minimax.ts
@@ -1,0 +1,182 @@
+import type {
+  GenerationRequest,
+  GenerationTask,
+  MediaGeneratorModel,
+  MediaGeneratorPlugin,
+  PollStatusResult,
+  WebSocketHandler,
+} from "./types";
+
+export const MINIMAX_MUSIC_CONFIG = {
+  endpoints: {
+    global_en: "https://api.minimax.io/v1/music_generation",
+    cn_zh: "https://api.minimaxi.com/v1/music_generation",
+  },
+  models: ["music-3.0", "music-2.6", "music-3.0-free", "music-2.6-free"],
+  outputFormats: ["url", "hex"],
+  streamOutputFormats: ["hex"],
+  audioFormats: ["mp3", "wav", "pcm"],
+  urlTtlHours: 24,
+} as const;
+
+type MiniMaxRegion = keyof typeof MINIMAX_MUSIC_CONFIG.endpoints;
+type MiniMaxAudioFormat = (typeof MINIMAX_MUSIC_CONFIG.audioFormats)[number];
+type MiniMaxOutputFormat = (typeof MINIMAX_MUSIC_CONFIG.outputFormats)[number];
+
+interface MiniMaxMusicResponse {
+  data?: { status?: number; audio?: string };
+  base_resp?: { status_code?: number; status_msg?: string };
+}
+
+function readChoice<T extends string>(
+  value: string | undefined,
+  choices: readonly T[],
+  fallback: T,
+): T {
+  return choices.find((choice) => choice === value) ?? fallback;
+}
+
+function readBoolean(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+function readPositiveInteger(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function musicModels(): MediaGeneratorModel[] {
+  return MINIMAX_MUSIC_CONFIG.models.map((id) => ({ id, name: id, type: "audio" }));
+}
+
+function assertSecureAudioUrl(audio: string): string {
+  let url: URL;
+  try {
+    url = new URL(audio);
+  } catch {
+    throw new Error("MiniMax music generation returned an invalid audio URL");
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("MiniMax music generation returned an insecure audio URL");
+  }
+  return audio;
+}
+
+export function parseMiniMaxMusicResponse(
+  result: MiniMaxMusicResponse,
+  outputFormat: MiniMaxOutputFormat = "url",
+  audioFormat: MiniMaxAudioFormat = "mp3",
+): string {
+  if (result.base_resp?.status_code !== 0) {
+    throw new Error(result.base_resp?.status_msg || "MiniMax music generation failed");
+  }
+  if (result.data?.status !== 2 || !result.data.audio) {
+    throw new Error("MiniMax music generation did not return completed audio");
+  }
+  if (outputFormat === "url") {
+    return assertSecureAudioUrl(result.data.audio);
+  }
+  if (
+    result.data.audio.length % 2 !== 0 ||
+    !/^[0-9a-f]+$/i.test(result.data.audio)
+  ) {
+    throw new Error("MiniMax music generation returned invalid hex audio");
+  }
+  const mediaType = audioFormat === "mp3" ? "mpeg" : audioFormat;
+  return `data:audio/${mediaType};base64,${Buffer.from(result.data.audio, "hex").toString("base64")}`;
+}
+
+export async function generateMiniMaxMusic(
+  request: GenerationRequest,
+): Promise<string> {
+  const apiKey = process.env.MINIMAX_API_KEY;
+  if (!apiKey) throw new Error("MINIMAX_API_KEY is not configured");
+  if (
+    request.type !== "audio" ||
+    !MINIMAX_MUSIC_CONFIG.models.some((model) => model === request.model)
+  ) {
+    throw new Error("Unsupported MiniMax music generation model");
+  }
+
+  const region = readChoice<MiniMaxRegion>(
+    process.env.MINIMAX_REGION,
+    ["global_en", "cn_zh"],
+    "global_en",
+  );
+  const audioFormat = readChoice<MiniMaxAudioFormat>(
+    process.env.MINIMAX_AUDIO_FORMAT,
+    MINIMAX_MUSIC_CONFIG.audioFormats,
+    "mp3",
+  );
+
+  const audioSetting: Record<string, string | number> = { format: audioFormat };
+  const sampleRate = readPositiveInteger(process.env.MINIMAX_SAMPLE_RATE);
+  const bitrate = readPositiveInteger(process.env.MINIMAX_BITRATE);
+  if (sampleRate !== undefined) audioSetting.sample_rate = sampleRate;
+  if (bitrate !== undefined) audioSetting.bitrate = bitrate;
+
+  const lyrics = process.env.MINIMAX_LYRICS?.trim();
+  const lyricsOptimizer = readBoolean(process.env.MINIMAX_LYRICS_OPTIMIZER);
+  const isInstrumental = readBoolean(process.env.MINIMAX_IS_INSTRUMENTAL);
+  const aigcWatermark = readBoolean(process.env.MINIMAX_AIGC_WATERMARK);
+
+  const payload: Record<string, unknown> = {
+    model: request.model,
+    prompt: request.prompt,
+    stream: false,
+    output_format: "url",
+    audio_setting: audioSetting,
+  };
+  if (lyrics) payload.lyrics = lyrics;
+  if (lyricsOptimizer !== undefined) payload.lyrics_optimizer = lyricsOptimizer;
+  if (isInstrumental !== undefined) payload.is_instrumental = isInstrumental;
+  if (region === "cn_zh" && aigcWatermark !== undefined) {
+    payload.aigc_watermark = aigcWatermark;
+  }
+
+  const response = await fetch(MINIMAX_MUSIC_CONFIG.endpoints[region], {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`MiniMax API error: ${response.status}`);
+  }
+  return parseMiniMaxMusicResponse(await response.json(), "url", audioFormat);
+}
+
+const noWebSocketHandler: WebSocketHandler = {
+  getInitMessage: () => "",
+  handleMessage: () => undefined,
+};
+
+export const minimaxGeneratorPlugin: MediaGeneratorPlugin = {
+  id: "minimax",
+  name: "MiniMax",
+  isConfigured: () => Boolean(process.env.MINIMAX_API_KEY),
+  isEnabled: () => minimaxGeneratorPlugin.isConfigured(),
+  getModels: () => (minimaxGeneratorPlugin.isEnabled() ? musicModels() : []),
+  async startGeneration(request: GenerationRequest): Promise<GenerationTask> {
+    const audio = await generateMiniMaxMusic(request);
+    return { taskId: "completed", socketAccessToken: audio };
+  },
+  getWebSocketUrl: () => "",
+  webSocketHandler: noWebSocketHandler,
+  async checkStatus(audio: string): Promise<PollStatusResult> {
+    const outputUrl = assertSecureAudioUrl(audio);
+    return {
+      status: "completed",
+      statusKey: "complete",
+      progress: 100,
+      outputUrls: [outputUrl],
+    };
+  },
+};


### PR DESCRIPTION
Reason: Add MiniMax music generation to the existing media generator registry.

- Register current music generation models for audio output.
- Route requests to the selected global or China endpoint with configurable lyrics and audio settings.
- Parse completed URL and hex audio responses and reject unsafe or invalid output.
- Document the optional runtime configuration and cover the registry, request payloads, formats, and errors with focused tests.

Checks:
- `npm test -- src/__tests__/lib/plugins/media-generators/minimax.test.ts`
- `npm run lint -- src/lib/plugins/media-generators/minimax.ts src/lib/plugins/media-generators/index.ts src/__tests__/lib/plugins/media-generators/minimax.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add MiniMax music generation to the media generator registry.
- Support global and China endpoints.
- Support configurable lyrics, audio format, sampling, bitrate, instrumental mode, and watermark settings.
- Parse URL and hexadecimal audio responses.
- Validate models, API responses, HTTPS URLs, and hexadecimal data.
- Add focused tests for configuration, requests, responses, and errors.
- Document optional MiniMax environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->